### PR TITLE
feat: add ISBN and keyword filters for book advert search (T5-1)

### DIFF
--- a/EcoScolarWebApi/Controllers/AdvertsController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertsController.cs
@@ -1,4 +1,5 @@
 using EcoscolarWebApi.Services;
+using EcoscolarWebApi.Utils.DTOs;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EcoscolarWebApi.Controllers
@@ -18,14 +19,28 @@ namespace EcoscolarWebApi.Controllers
         }
 
         /// <summary>
-        /// Retrieves a list of advert summaries for the catalog.
-        /// GET api/v1/adverts
+        /// Liste / recherche d'annonces (résumés). GET api/v1/adverts?q=...&amp;minPrice=...
         /// </summary>
         [HttpGet]
-        public async Task<IActionResult> GetSummaries(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> SearchSummaries(
+            [FromQuery] AdvertSearchQuery? query,
+            CancellationToken cancellationToken = default)
         {
-            var items = await _advertSearchService.GetSummariesAsync();
+            var items = await _advertSearchService.SearchSummariesAsync(query, cancellationToken);
             return Ok(items);
+        }
+
+        /// <summary>Détail d'une annonce. GET api/v1/adverts/{id}</summary>
+        [HttpGet("{id:guid}")]
+        public async Task<IActionResult> GetDetail(Guid id, CancellationToken cancellationToken = default)
+        {
+            var detail = await _advertSearchService.GetDetailAsync(id, cancellationToken);
+            if (detail is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(detail);
         }
     }
 }

--- a/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
@@ -18,12 +18,75 @@ namespace EcoscolarWebApi.Services
                     Id = Guid.Parse("9a2d7d6e-8b4c-4d55-a901-2ec6f6c4d202"),
                     Title = "Exemple annonce 2",
                     Price = 7.00m
+                },
+                new()
+                {
+                    Id = Guid.Parse("3f8e5c9b-2a7e-4f1a-9c3d-5b6e7f8a9c03"),
+                    Title = "Exemple annonce 3",
+                    Kind = AdvertKind.Book,
+                    Isbn = "978-3-16-148410-0",
+                    Category = "Fiction",
+                    Subject = "Mathematics",
+                    Grade = "Grade 10",
+                    Price = 15.00m
                 }
             };
 
-        public Task<IEnumerable<AdvertSummaryDto>> GetSummariesAsync()
+        public Task<IEnumerable<AdvertSummaryDto>> SearchSummariesAsync(AdvertSearchQuery? query, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IEnumerable<AdvertSummaryDto>>(Summaries);
+            // Étape B : aucun critère dans l'URL → toute la liste
+            if (query == null)
+            {
+                return Task.FromResult<IEnumerable<AdvertSummaryDto>>(Summaries);
+            }
+
+            // Point de départ pour les filtres (étapes C, D — T5-1 puis T5-2/T5-3)
+            IEnumerable<AdvertSummaryDto> result = Summaries;
+
+            if (!string.IsNullOrWhiteSpace(query.Isbn))
+            {
+                var needle = Normalize(query.Isbn);
+                result = result.Where(a =>
+                    a.Kind == AdvertKind.Book
+                    && a.Isbn is not null
+                    && Normalize(a.Isbn).Contains(needle, StringComparison.Ordinal));
+            }
+
+            if (!string.IsNullOrWhiteSpace(query.Q))
+            {
+                var keyword = query.Q.Trim();
+                result = result.Where(a =>
+                    a.Kind == AdvertKind.Book
+                    && (a.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase)
+                        || (a.Isbn is not null
+                            && a.Isbn.Contains(keyword, StringComparison.OrdinalIgnoreCase))));
+            }
+
+            return Task.FromResult<IEnumerable<AdvertSummaryDto>>(result.ToList());
+        }
+
+        public Task<AdvertDetailDto?> GetDetailAsync(Guid id, CancellationToken cancellationToken)
+        {
+            var summary = Summaries.FirstOrDefault(s => s.Id == id);
+            if (summary == null)
+                return Task.FromResult<AdvertDetailDto?>(null);
+
+            return Task.FromResult<AdvertDetailDto?>(new AdvertDetailDto
+            {
+                Id = summary.Id,
+                Title = summary.Title,
+                Kind = summary.Kind,
+                Isbn = summary.Isbn,
+                Category = summary.Category,
+                Subject = summary.Subject,
+                Grade = summary.Grade,
+                Price = summary.Price
+            });
+        }
+
+        private static string Normalize(string? isbnText)
+        {
+            return isbnText?.Trim().ToLowerInvariant().Replace("-", string.Empty) ?? string.Empty;
         }
     }
 }

--- a/EcoScolarWebApi/Services/IAdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/IAdvertSearchService.cs
@@ -4,6 +4,7 @@ namespace EcoscolarWebApi.Services
 {
     public interface IAdvertSearchService
     {
-        Task<IEnumerable<AdvertSummaryDto>> GetSummariesAsync();
+        Task<IEnumerable<AdvertSummaryDto>> SearchSummariesAsync(AdvertSearchQuery? query, CancellationToken cancellationToken = default);
+        Task<AdvertDetailDto?> GetDetailAsync(Guid id, CancellationToken cancellationToken);
     }
 }

--- a/EcoScolarWebApi/Utils/DTOs/AdvertDetailDto.cs
+++ b/EcoScolarWebApi/Utils/DTOs/AdvertDetailDto.cs
@@ -1,14 +1,16 @@
 namespace EcoscolarWebApi.Utils.DTOs
 {
-	public class AdvertSummaryDto
+	public class AdvertDetailDto
 	{
 		public Guid Id { get; set; }
+		public AdvertKind Kind { get; set; }
 		public string Title { get; set; } = string.Empty;
 		public decimal Price { get; set; }
-		public AdvertKind Kind { get; set; }
-		public string? Isbn { get; set; } = null;
+		public string? Isbn { get; set; }
 		public string? Category { get; set; }
 		public string? Subject { get; set; }
 		public string? Grade { get; set; }
-    }
-}	
+		public string Description { get; set; } = string.Empty;
+		public string? ImageUrl { get; set; }
+	}
+}

--- a/EcoScolarWebApi/Utils/DTOs/AdvertKind.cs
+++ b/EcoScolarWebApi/Utils/DTOs/AdvertKind.cs
@@ -1,0 +1,9 @@
+﻿namespace EcoscolarWebApi.Utils.DTOs
+{
+    public enum AdvertKind
+    {
+       Book,
+       Product,
+       Service
+    }
+}

--- a/EcoScolarWebApi/Utils/DTOs/AdvertSearchQuery.cs
+++ b/EcoScolarWebApi/Utils/DTOs/AdvertSearchQuery.cs
@@ -1,0 +1,13 @@
+﻿namespace EcoscolarWebApi.Utils.DTOs
+{
+    public class AdvertSearchQuery
+    {
+        public string? Q { get; set; }
+        public string? Isbn { get; set; }
+        public string? Category { get; set; }
+        public decimal? MinPrice { get; set; } = null;
+        public decimal? MaxPrice { get; set; }
+        public string? Subject { get; set; }
+        public string? Grade { get; set; }
+    }
+}


### PR DESCRIPTION
Added filters on the mock advert list for books — you can filter with isbn and with q (matches title or ISBN). This covers T5-1 / UC-06 on the backend.

Quick check in Swagger: GET /api/v1/adverts with or without ?isbn= / ?q=.