### PR TITLE
Feature/service search

### DIFF
--- a/EcoScolarWebApi/Controllers/AdvertsController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertsController.cs
@@ -131,22 +131,34 @@ namespace EcoscolarWebApi.Controllers
         /// 
         /// GET: AdvertsController/GetServices
         /// Url: /api/v1/adverts/services
+        /// q query parameter allows to filter services by title or description containing the provided keyword (case-insensitive)
         /// </summary>
         /// <returns>List of formatted service adverts</returns>
         [HttpGet("services")]
-        public async Task<ActionResult<IEnumerable<AdvertReadDto>>> GetServices()
+        public async Task<ActionResult<IEnumerable<AdvertReadDto>>> GetServices([FromQuery] string? q)
         {
             IEnumerable<AdvertServices> services;
             try
             {
-                services = await _context.Services
+                var query = _context.Services
                     .Include(s => s.User)
-                    .ToListAsync();
+                    .AsQueryable();
+
+                if (!string.IsNullOrWhiteSpace(q))
+                {
+                    var probe = q.Trim().ToLower();
+                    query = query.Where(s =>
+                        s.Title.ToLower().Contains(probe)
+                        || s.Description.ToLower().Contains(probe));
+                }
+
+                services = await query.ToListAsync();
             }
             catch (Exception e)
             {
                 return BadRequest(new { error = e.Message });
             }
+
             return Ok(services.Select(AdvertReadDto.FromEntity));
         }
 

--- a/EcoScolarWebApi/Controllers/AdvertsController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertsController.cs
@@ -98,15 +98,26 @@ namespace EcoscolarWebApi.Controllers
         /// </summary>
         /// <returns>List of formatted product adverts</returns>
         [HttpGet("products")]
-        public async Task<ActionResult<IEnumerable<AdvertReadDto>>> GetProducts()
+        public async Task<ActionResult<IEnumerable<AdvertReadDto>>> GetProducts(
+                [FromQuery] long? categoryId,
+                [FromQuery] decimal? maxPrice)
         {
             IEnumerable<PhysicalItems> products;
             try
             {
-                products = await _context.Products
+                var query = _context.Products
                     .Include(p => p.User)
                     .Include(p => p.Pictures)
-                    .ToListAsync();
+                    .Where(p => !_context.Set<Books>().Any(b => b.AdvertId == p.AdvertId));
+                if (categoryId.HasValue)
+                {
+                    query = query.Where(p => p.ProductCategoryId == categoryId.Value);
+                }
+                if (maxPrice.HasValue)
+                {
+                    query = query.Where(p => p.Price <= maxPrice.Value);
+                }
+                products = await query.ToListAsync();
             }
             catch (Exception e)
             {

--- a/EcoScolarWebApi/Data/EcoscolarDbContext.cs
+++ b/EcoScolarWebApi/Data/EcoscolarDbContext.cs
@@ -35,6 +35,7 @@ namespace EcoscolarWebApi.Data
         public DbSet<Books> Books { get; set; } = default!;
 
         public DbSet<Pictures> Pictures { get; set; } = default!;
+        public DbSet<ProductCategories> ProductCategories { get; set; } = default!;
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -52,6 +53,9 @@ namespace EcoscolarWebApi.Data
             );
             builder.Entity<SchoolGrades>().HasData(
                 new SchoolGrades { SchoolGradeId = 1, Name = "École Supérieur", SchoolGrade = "ES"}
+            );
+            builder.Entity<ProductCategories>().HasData(
+                new ProductCategories { ProductCategoryId = 1, Name = "Fournitures", Description = "Catégorie exemple pour produits non-livres" }
             );
         }
     }

--- a/EcoScolarWebApi/Data/EcoscolarDbContext.cs
+++ b/EcoScolarWebApi/Data/EcoscolarDbContext.cs
@@ -40,6 +40,11 @@ namespace EcoscolarWebApi.Data
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
+            builder.Entity<PhysicalItems>()
+                .HasOne(p => p.ProductCategory)
+                .WithMany(c => c.PhysicalItems)
+                .HasForeignKey(p => p.ProductCategoryId)
+                .OnDelete(DeleteBehavior.Restrict);
             this.seeding(builder);
         }
 

--- a/EcoScolarWebApi/Migrations/20260518110945_AddProductCategoriesAndFk.Designer.cs
+++ b/EcoScolarWebApi/Migrations/20260518110945_AddProductCategoriesAndFk.Designer.cs
@@ -4,6 +4,7 @@ using EcoscolarWebApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EcoscolarWebApi.Migrations
 {
     [DbContext(typeof(EcoscolarDbContext))]
-    partial class EcoscolarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518110945_AddProductCategoriesAndFk")]
+    partial class AddProductCategoriesAndFk
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EcoScolarWebApi/Migrations/20260518110945_AddProductCategoriesAndFk.cs
+++ b/EcoScolarWebApi/Migrations/20260518110945_AddProductCategoriesAndFk.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoscolarWebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProductCategoriesAndFk : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "ProductCategoriesProductCategoryId",
+                table: "PhysicalItems",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ProductCategoryId",
+                table: "PhysicalItems",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ProductCategories",
+                columns: table => new
+                {
+                    ProductCategoryId = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProductCategories", x => x.ProductCategoryId);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "BookCategories",
+                keyColumn: "BookCategoryId",
+                keyValue: 1L,
+                column: "Description",
+                value: "description");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PhysicalItems_ProductCategoriesProductCategoryId",
+                table: "PhysicalItems",
+                column: "ProductCategoriesProductCategoryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PhysicalItems_ProductCategories_ProductCategoriesProductCategoryId",
+                table: "PhysicalItems",
+                column: "ProductCategoriesProductCategoryId",
+                principalTable: "ProductCategories",
+                principalColumn: "ProductCategoryId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PhysicalItems_ProductCategories_ProductCategoriesProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.DropTable(
+                name: "ProductCategories");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PhysicalItems_ProductCategoriesProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProductCategoriesProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.UpdateData(
+                table: "BookCategories",
+                keyColumn: "BookCategoryId",
+                keyValue: 1L,
+                column: "Description",
+                value: "desciption");
+        }
+    }
+}

--- a/EcoScolarWebApi/Migrations/20260518153404_FixProductCategoryForeignKey.Designer.cs
+++ b/EcoScolarWebApi/Migrations/20260518153404_FixProductCategoryForeignKey.Designer.cs
@@ -4,6 +4,7 @@ using EcoscolarWebApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EcoscolarWebApi.Migrations
 {
     [DbContext(typeof(EcoscolarDbContext))]
-    partial class EcoscolarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518153404_FixProductCategoryForeignKey")]
+    partial class FixProductCategoryForeignKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EcoScolarWebApi/Migrations/20260518153404_FixProductCategoryForeignKey.cs
+++ b/EcoScolarWebApi/Migrations/20260518153404_FixProductCategoryForeignKey.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoscolarWebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixProductCategoryForeignKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PhysicalItems_ProductCategories_ProductCategoriesProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PhysicalItems_ProductCategoriesProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.DropColumn(
+                name: "ProductCategoriesProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.InsertData(
+                table: "ProductCategories",
+                columns: new[] { "ProductCategoryId", "Description", "Name" },
+                values: new object[] { 1L, "Catégorie exemple pour produits non-livres", "Fournitures" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PhysicalItems_ProductCategoryId",
+                table: "PhysicalItems",
+                column: "ProductCategoryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PhysicalItems_ProductCategories_ProductCategoryId",
+                table: "PhysicalItems",
+                column: "ProductCategoryId",
+                principalTable: "ProductCategories",
+                principalColumn: "ProductCategoryId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PhysicalItems_ProductCategories_ProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PhysicalItems_ProductCategoryId",
+                table: "PhysicalItems");
+
+            migrationBuilder.DeleteData(
+                table: "ProductCategories",
+                keyColumn: "ProductCategoryId",
+                keyValue: 1L);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ProductCategoriesProductCategoryId",
+                table: "PhysicalItems",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PhysicalItems_ProductCategoriesProductCategoryId",
+                table: "PhysicalItems",
+                column: "ProductCategoriesProductCategoryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PhysicalItems_ProductCategories_ProductCategoriesProductCategoryId",
+                table: "PhysicalItems",
+                column: "ProductCategoriesProductCategoryId",
+                principalTable: "ProductCategories",
+                principalColumn: "ProductCategoryId");
+        }
+    }
+}

--- a/EcoScolarWebApi/Models/PhysicalItems.cs
+++ b/EcoScolarWebApi/Models/PhysicalItems.cs
@@ -13,5 +13,9 @@ namespace EcoscolarWebApi.Models
         [Column(TypeName = "decimal(18,2)")]
         public decimal? Weight { get; set; }
         public virtual ICollection<Pictures> Pictures { get; set; } = new List<Pictures>();
+        public long? ProductCategoryId { get; set; }
+
+        [ForeignKey(nameof(ProductCategoryId))]
+        public virtual ProductCategories? ProductCategory { get; set; }
     }
 }

--- a/EcoScolarWebApi/Models/ProductCategories.cs
+++ b/EcoScolarWebApi/Models/ProductCategories.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace EcoscolarWebApi.Models
+{
+    [Table("ProductCategories")]
+    public class ProductCategories
+    {
+        [Key]
+        public long ProductCategoryId { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string Name { get; set; }
+
+        [Required]
+        [StringLength(1000)]
+        public string Description { get; set; }
+
+        public virtual ICollection<PhysicalItems> PhysicalItems { get; set; } = new List<PhysicalItems>();
+    }
+}

--- a/EcoScolarWebApi/Services/AdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/AdvertSearchService.cs
@@ -6,8 +6,10 @@ using Microsoft.EntityFrameworkCore;
 namespace EcoscolarWebApi.Services
 {
     /// <summary>
-    /// Catalogue summaries/detail backed by EF Core (<see cref="Books"/>). Same contract as <see cref="FakeAdvertSearchService"/>.
-    /// <see cref="AdvertSummaryDto.Id"/> is a deterministic <see cref="Guid"/> encoding <see cref="Adverts.AdvertId"/> for stable REST paths until the API settles on long ids.
+    /// Catalogue summaries/detail sur <see cref="Adverts"/> (livres, produits hors livre, services).
+    /// Filtre <c>isbn</c> : lignes résolues comme annonces reliées à <see cref="Books"/>.
+    /// Filtre <c>q</c> : titre ou ISBN (pour les lignes livre uniquement dans la sous-requête).
+    /// <see cref="AdvertSummaryDto.Id"/> encode <see cref="Adverts.AdvertId"/> en <see cref="Guid"/>.
     /// </summary>
     public sealed class AdvertSearchService : IAdvertSearchService
     {
@@ -22,20 +24,18 @@ namespace EcoscolarWebApi.Services
             AdvertSearchQuery? query,
             CancellationToken cancellationToken = default)
         {
-            // Filtres sur IQueryable pour que WHERE / JOIN partent au serveur SQL (voir PR Copilot perf).
-            IQueryable<Books> q = _context.Books
-                .AsNoTracking()
-                .AsSplitQuery()
-                .Include(b => b.BookCategory)
-                .Include(b => b.Pictures);
+            IQueryable<Adverts> advertsQuery = _context.Adverts.AsNoTracking();
 
             if (query != null && !string.IsNullOrWhiteSpace(query.Isbn))
             {
                 var needle = Normalize(query.Isbn);
-                q = q.Where(b =>
-                    b.ISBN != null
-                    && b.ISBN.Trim() != string.Empty
-                    && b.ISBN.Replace("-", string.Empty).Trim().ToLower().Contains(needle));
+
+                advertsQuery = advertsQuery.Where(a =>
+                    _context.Set<Books>().Any(b =>
+                        b.AdvertId == a.AdvertId
+                        && b.ISBN != null
+                        && b.ISBN.Trim() != string.Empty
+                        && b.ISBN.Replace("-", string.Empty).Trim().ToLower().Contains(needle)));
             }
 
             if (query != null && !string.IsNullOrWhiteSpace(query.Q))
@@ -44,16 +44,37 @@ namespace EcoscolarWebApi.Services
                 var titleProbe = keyword.ToLower();
                 var isbnProbe = Normalize(keyword);
 
-                q = q.Where(b =>
-                    b.Title.ToLower().Contains(titleProbe)
-                    || (b.ISBN != null
+                advertsQuery = advertsQuery.Where(a =>
+                    a.Title.ToLower().Contains(titleProbe)
+                    || _context.Set<Books>().Any(b =>
+                        b.AdvertId == a.AdvertId
+                        && b.ISBN != null
                         && b.ISBN.Trim() != string.Empty
                         && b.ISBN.Replace("-", string.Empty).Trim().ToLower().Contains(isbnProbe)));
             }
 
-            var books = await q.ToListAsync(cancellationToken);
+            var adverts = await advertsQuery.ToListAsync(cancellationToken);
 
-            return books.Select(ToSummaryDto).ToList();
+            var bookAdvertIds = adverts.OfType<Books>().Select(b => b.AdvertId).Distinct().ToArray();
+            var serviceAdvertIds = adverts.OfType<AdvertServices>().Select(s => s.AdvertId).Distinct().ToArray();
+
+            var booksDict = bookAdvertIds.Length == 0
+                ? []
+                : await _context.Books.AsNoTracking()
+                    .Include(b => b.BookCategory)
+                    .Include(b => b.Pictures)
+                    .Where(b => bookAdvertIds.Contains(b.AdvertId))
+                    .ToDictionaryAsync(b => b.AdvertId, cancellationToken);
+
+            var servicesDict = serviceAdvertIds.Length == 0
+                ? []
+                : await _context.Services.AsNoTracking()
+                    .Include(s => s.Subject)
+                    .Include(s => s.SchoolGrade)
+                    .Where(s => serviceAdvertIds.Contains(s.AdvertId))
+                    .ToDictionaryAsync(s => s.AdvertId, cancellationToken);
+
+            return adverts.Select(a => MapSummary(a, booksDict, servicesDict)).ToList();
         }
 
         public async Task<AdvertDetailDto?> GetDetailAsync(Guid id, CancellationToken cancellationToken = default)
@@ -61,31 +82,90 @@ namespace EcoscolarWebApi.Services
             if (!TryAdvertIdFromCatalogGuid(id, out var advertId))
                 return null;
 
-            var book = await _context.Books
+            var bookDetail = await _context.Books
                 .AsNoTracking()
                 .Include(b => b.BookCategory)
                 .Include(b => b.Pictures)
                 .FirstOrDefaultAsync(b => b.AdvertId == advertId, cancellationToken);
+            if (bookDetail != null)
+                return ToDetailFromBook(bookDetail, id);
 
-            return book == null ? null : ToDetailDto(book, id);
+            var serviceDetail = await _context.Services
+                .AsNoTracking()
+                .Include(s => s.Subject)
+                .Include(s => s.SchoolGrade)
+                .FirstOrDefaultAsync(s => s.AdvertId == advertId, cancellationToken);
+            if (serviceDetail != null)
+                return ToDetailFromService(serviceDetail, id);
+
+            var productDetail = await _context.Products
+                .AsNoTracking()
+                .Include(p => p.Pictures)
+                .Where(p =>
+                    p.AdvertId == advertId
+                    && !_context.Set<Books>().Any(book => book.AdvertId == p.AdvertId))
+                .FirstOrDefaultAsync(cancellationToken);
+
+            return productDetail == null ? null : ToDetailFromPhysical(productDetail, id);
         }
 
-        private static AdvertSummaryDto ToSummaryDto(Books b)
+        private static AdvertSummaryDto MapSummary(
+            Adverts a,
+            Dictionary<long, Books> booksDict,
+            Dictionary<long, AdvertServices> servicesDict)
         {
-            return new AdvertSummaryDto
+            switch (a)
             {
-                Id = CatalogIdFromAdvertId(b.AdvertId),
-                Title = b.Title,
-                Price = b.Price,
-                Type = CatalogAdvertTypeCodes.Book,
-                Isbn = string.IsNullOrWhiteSpace(b.ISBN) ? null : b.ISBN,
-                Category = b.BookCategory?.Name,
-                Subject = null,
-                Grade = null
-            };
+                case Books bk:
+                {
+                    booksDict.TryGetValue(bk.AdvertId, out var fullBk);
+                    var src = fullBk ?? bk;
+                    return new AdvertSummaryDto
+                    {
+                        Id = CatalogIdFromAdvertId(bk.AdvertId),
+                        Title = bk.Title,
+                        Price = bk.Price,
+                        Type = CatalogAdvertTypeCodes.Book,
+                        Isbn = string.IsNullOrWhiteSpace(src.ISBN) ? null : src.ISBN,
+                        Category = src.BookCategory?.Name,
+                        Subject = null,
+                        Grade = null
+                    };
+                }
+                case AdvertServices svc:
+                {
+                    servicesDict.TryGetValue(svc.AdvertId, out var fullSvc);
+                    var src = fullSvc ?? svc;
+                    return new AdvertSummaryDto
+                    {
+                        Id = CatalogIdFromAdvertId(svc.AdvertId),
+                        Title = svc.Title,
+                        Price = svc.Price,
+                        Type = CatalogAdvertTypeCodes.Service,
+                        Isbn = null,
+                        Category = null,
+                        Subject = src.Subject?.Name,
+                        Grade = src.SchoolGrade?.Name
+                    };
+                }
+                case PhysicalItems phy when phy is not Books:
+                    return new AdvertSummaryDto
+                    {
+                        Id = CatalogIdFromAdvertId(phy.AdvertId),
+                        Title = phy.Title,
+                        Price = phy.Price,
+                        Type = CatalogAdvertTypeCodes.Product,
+                        Isbn = null,
+                        Category = null,
+                        Subject = null,
+                        Grade = null
+                    };
+                default:
+                    throw new InvalidOperationException($"Unknown advert CLR type '{a.GetType().Name}'.");
+            }
         }
 
-        private static AdvertDetailDto ToDetailDto(Books b, Guid catalogId)
+        private static AdvertDetailDto ToDetailFromBook(Books b, Guid catalogId)
         {
             string? imageUrl = b.Pictures?.FirstOrDefault()?.Label;
 
@@ -100,6 +180,41 @@ namespace EcoscolarWebApi.Services
                 Grade = null,
                 Price = b.Price,
                 Description = b.Description ?? string.Empty,
+                ImageUrl = imageUrl
+            };
+        }
+
+        private static AdvertDetailDto ToDetailFromService(AdvertServices s, Guid catalogId)
+        {
+            return new AdvertDetailDto
+            {
+                Id = catalogId,
+                Title = s.Title,
+                Type = CatalogAdvertTypeCodes.Service,
+                Isbn = null,
+                Category = null,
+                Subject = s.Subject?.Name,
+                Grade = s.SchoolGrade?.Name,
+                Price = s.Price,
+                Description = s.Description ?? string.Empty,
+                ImageUrl = null
+            };
+        }
+
+        private static AdvertDetailDto ToDetailFromPhysical(PhysicalItems p, Guid catalogId)
+        {
+            string? imageUrl = p.Pictures?.FirstOrDefault()?.Label;
+            return new AdvertDetailDto
+            {
+                Id = catalogId,
+                Title = p.Title,
+                Type = CatalogAdvertTypeCodes.Product,
+                Isbn = null,
+                Category = null,
+                Subject = null,
+                Grade = null,
+                Price = p.Price,
+                Description = p.Description ?? string.Empty,
                 ImageUrl = imageUrl
             };
         }

--- a/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
@@ -25,13 +25,11 @@ namespace EcoscolarWebApi.Services
             AdvertSearchQuery? query,
             CancellationToken cancellationToken = default)
         {
-            // Étape B : aucun critère dans l'URL → toute la liste
             if (query == null)
             {
                 return Task.FromResult<IEnumerable<AdvertSummaryDto>>(Summaries);
             }
 
-            // Point de départ pour les filtres (étapes C, D — T5-1 puis T5-2/T5-3)
             IEnumerable<AdvertSummaryDto> result = Summaries;
 
             if (!string.IsNullOrWhiteSpace(query.Isbn))

--- a/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
@@ -1,25 +1,21 @@
-using EcoscolarWebApi.Models;
 using EcoscolarWebApi.Utils.DTOs;
-using EcoscolarWebApi.Utils.Enums;
 
 namespace EcoscolarWebApi.Services
 {
     /// <summary>
-    /// Mock search (T5-1): <c>Isbn</c> and <c>Q</c> filters apply to <see cref="CatalogAdvertTypeCodes.Book"/> adverts only.
-    /// Seed data uses domain <see cref="Books"/> (inherits <see cref="Adverts"/>) then maps to API DTOs.
-    /// Product/service filters come in T5-2 / T5-3.
+    /// Mock catalogue search aligned with <see cref="AdvertSearchService"/>:
+    /// <c>isbn</c> keeps book rows whose normalized ISBN matches;
+    /// <c>q</c> keeps rows whose title contains the keyword (any advert type)
+    /// or whose book ISBN matches the normalized keyword.
     /// </summary>
     public class FakeAdvertSearchService : IAdvertSearchService
     {
-        private sealed record CatalogBookSeed(Books Book, Guid CatalogId, string? Subject, string? Grade);
+        private sealed record CatalogMockEntry(AdvertSummaryDto Summary, string Description);
 
-        /// <remarks>
-        /// <see cref="Guid"/> preserves stable mock catalogue IDs for REST paths; EF uses <see cref="Adverts.AdvertId"/> independently.
-        /// </remarks>
-        private static readonly IReadOnlyList<CatalogBookSeed> CatalogSeed = BuildCatalogSeed();
+        private static readonly IReadOnlyList<CatalogMockEntry> Catalog = BuildCatalog();
 
         private static readonly IReadOnlyList<AdvertSummaryDto> Summaries =
-            CatalogSeed.Select(ToSummaryDto).ToList();
+            Catalog.Select(e => e.Summary).ToList();
 
         public Task<IEnumerable<AdvertSummaryDto>> SearchSummariesAsync(
             AdvertSearchQuery? query,
@@ -46,10 +42,10 @@ namespace EcoscolarWebApi.Services
                 var keyword = query.Q.Trim();
                 var normalizedIsbnProbe = Normalize(keyword);
                 result = result.Where(a =>
-                    a.Type == CatalogAdvertTypeCodes.Book
-                    && (a.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase)
-                        || (a.Isbn is not null
-                            && Normalize(a.Isbn).Contains(normalizedIsbnProbe, StringComparison.Ordinal))));
+                    a.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase)
+                    || (a.Type == CatalogAdvertTypeCodes.Book
+                        && a.Isbn is not null
+                        && Normalize(a.Isbn).Contains(normalizedIsbnProbe, StringComparison.Ordinal)));
             }
 
             return Task.FromResult<IEnumerable<AdvertSummaryDto>>(result.ToList());
@@ -57,13 +53,11 @@ namespace EcoscolarWebApi.Services
 
         public Task<AdvertDetailDto?> GetDetailAsync(Guid id, CancellationToken cancellationToken = default)
         {
-            var seed = CatalogSeed.FirstOrDefault(s => s.CatalogId == id);
-            if (seed == null)
+            var entry = Catalog.FirstOrDefault(e => e.Summary.Id == id);
+            if (entry == null)
                 return Task.FromResult<AdvertDetailDto?>(null);
 
-            var s = ToSummaryDto(seed);
-            var b = seed.Book;
-
+            var s = entry.Summary;
             return Task.FromResult<AdvertDetailDto?>(new AdvertDetailDto
             {
                 Id = s.Id,
@@ -74,117 +68,93 @@ namespace EcoscolarWebApi.Services
                 Subject = s.Subject,
                 Grade = s.Grade,
                 Price = s.Price,
-                Description = b.Description ?? string.Empty
+                Description = entry.Description
             });
         }
 
-        private static IReadOnlyList<CatalogBookSeed> BuildCatalogSeed()
+        private static IReadOnlyList<CatalogMockEntry> BuildCatalog()
         {
-            var categoryGeneral = new BookCategories
-            {
-                BookCategoryId = 1,
-                Name = "General",
-                Description = "Mock category (catalogue démo)."
-            };
+            const string demoDesc = "Données de démonstration (catalogue mock). Non persistées.";
 
-            var categoryFiction = new BookCategories
+            return new List<CatalogMockEntry>
             {
-                BookCategoryId = 2,
-                Name = "Fiction",
-                Description = "Fiction mock (catalogue démo)."
-            };
-
-            const string mockUserId = "00000000-0000-4000-8000-000000000099";
-            var catalogUser = new User
-            {
-                Id = mockUserId,
-                UserName = "catalog-mock-user",
-                Email = "catalog-mock@ecoscolar.invalid"
-            };
-
-            return new List<CatalogBookSeed>
-            {
-                new(SeedMockBook(
-                        catalogUser,
-                        advertId: 101,
-                        "Exemple annonce 1",
-                        12.50m,
-                        isbnForEntity: "",
-                        categoryGeneral),
-                    Guid.Parse("6d4b9d4a-1dd1-4a38-8d68-7af4d9cb3c01"),
-                    Subject: null,
-                    Grade: null),
-                new(SeedMockBook(
-                        catalogUser,
-                        advertId: 102,
-                        "Exemple annonce 2",
-                        7.00m,
-                        isbnForEntity: "",
-                        categoryGeneral),
-                    Guid.Parse("9a2d7d6e-8b4c-4d55-a901-2ec6f6c4d202"),
-                    Subject: null,
-                    Grade: null),
-                new(SeedMockBook(
-                        catalogUser,
-                        advertId: 103,
-                        "Exemple annonce 3",
-                        15.00m,
-                        isbnForEntity: "978-3-16-148410-0",
-                        categoryFiction),
-                    Guid.Parse("3f8e5c9b-2a7e-4f1a-9c3d-5b6e7f8a9c03"),
-                    Subject: "Mathematics",
-                    Grade: "Grade 10")
-            };
-        }
-
-        /// <summary>Build a non-persisted <see cref="Books"/> graph for catalogue mock only.</summary>
-        private static Books SeedMockBook(
-            User seller,
-            long advertId,
-            string title,
-            decimal price,
-            string isbnForEntity,
-            BookCategories category)
-        {
-            var now = DateTime.UtcNow;
-            var book = new Books
-            {
-                AdvertId = advertId,
-                Title = title,
-                Description = "Données de démonstration (catalogue mock). Non persistées.",
-                Price = price,
-                CreatedAt = now,
-                NotificationDate = now.AddMonths(3),
-                Status = AdvertStatus.ACTIVE,
-                UserId = seller.Id ?? string.Empty,
-                User = seller,
-                Condition = Condition.NEW,
-                Pictures = new List<Pictures>(),
-                ISBN = isbnForEntity,
-                Author = "—",
-                Publisher = "—",
-                Edition = "—",
-                WrittenLanguage = Language.FR,
-                BookCategoryId = category.BookCategoryId,
-                BookCategory = category
-            };
-
-            return book;
-        }
-
-        private static AdvertSummaryDto ToSummaryDto(CatalogBookSeed seed)
-        {
-            var b = seed.Book;
-            return new AdvertSummaryDto
-            {
-                Id = seed.CatalogId,
-                Title = b.Title,
-                Price = b.Price,
-                Type = CatalogAdvertTypeCodes.Book,
-                Isbn = string.IsNullOrWhiteSpace(b.ISBN) ? null : b.ISBN,
-                Category = b.BookCategory?.Name,
-                Subject = seed.Subject,
-                Grade = seed.Grade
+                new(new AdvertSummaryDto
+                {
+                    Id = Guid.Parse("6d4b9d4a-1dd1-4a38-8d68-7af4d9cb3c01"),
+                    Title = "Exemple annonce 1",
+                    Price = 12.50m,
+                    Type = CatalogAdvertTypeCodes.Book,
+                    Isbn = null,
+                    Category = "General",
+                    Subject = null,
+                    Grade = null
+                }, demoDesc),
+                new(new AdvertSummaryDto
+                {
+                    Id = Guid.Parse("9a2d7d6e-8b4c-4d55-a901-2ec6f6c4d202"),
+                    Title = "Exemple annonce 2",
+                    Price = 7.00m,
+                    Type = CatalogAdvertTypeCodes.Book,
+                    Isbn = null,
+                    Category = "General",
+                    Subject = null,
+                    Grade = null
+                }, demoDesc),
+                new(new AdvertSummaryDto
+                {
+                    Id = Guid.Parse("3f8e5c9b-2a7e-4f1a-9c3d-5b6e7f8a9c03"),
+                    Title = "Exemple annonce 3",
+                    Price = 15.00m,
+                    Type = CatalogAdvertTypeCodes.Book,
+                    Isbn = "978-3-16-148410-0",
+                    Category = "Fiction",
+                    Subject = "Mathematics",
+                    Grade = "Grade 10"
+                }, demoDesc),
+                new(new AdvertSummaryDto
+                {
+                    Id = Guid.Parse("c4d8f2a1-6e9b-4c7d-a5f3-1e2d3c4b5a01"),
+                    Title = "Calculatrice scientifique Casio",
+                    Price = 42.99m,
+                    Type = CatalogAdvertTypeCodes.Product,
+                    Isbn = null,
+                    Category = "Fournitures",
+                    Subject = null,
+                    Grade = null
+                }, demoDesc),
+                new(new AdvertSummaryDto
+                {
+                    Id = Guid.Parse("c4d8f2a1-6e9b-4c7d-a5f3-1e2d3c4b5a02"),
+                    Title = "Cartable à roulettes bleu marine",
+                    Price = 59.90m,
+                    Type = CatalogAdvertTypeCodes.Product,
+                    Isbn = null,
+                    Category = "Fournitures",
+                    Subject = null,
+                    Grade = null
+                }, demoDesc),
+                new(new AdvertSummaryDto
+                {
+                    Id = Guid.Parse("e7b3c91d-5f44-4a8e-b2c6-9d8e7f6a5b03"),
+                    Title = "Cours particuliers mathématiques",
+                    Price = 25.00m,
+                    Type = CatalogAdvertTypeCodes.Service,
+                    Isbn = null,
+                    Category = null,
+                    Subject = "Mathématiques",
+                    Grade = "Collège"
+                }, demoDesc),
+                new(new AdvertSummaryDto
+                {
+                    Id = Guid.Parse("e7b3c91d-5f44-4a8e-b2c6-9d8e7f6a5b04"),
+                    Title = "Soutien physique chimie niveau lycée",
+                    Price = 30.00m,
+                    Type = CatalogAdvertTypeCodes.Service,
+                    Isbn = null,
+                    Category = null,
+                    Subject = "Physique-Chimie",
+                    Grade = "Lycée"
+                }, demoDesc)
             };
         }
 

--- a/EcoScolarWebApi/Utils/DTOs/Advert/AdvertDto.cs
+++ b/EcoScolarWebApi/Utils/DTOs/Advert/AdvertDto.cs
@@ -143,7 +143,8 @@ namespace EcoscolarWebApi.Utils.DTOs.Advert
     /// <param name="UserId">The ID of the user who is creating the product advert</param>
     /// <param name="Images">The array of image URLs for the product advert</param>
     /// <param name="Condition">The condition of the product advert</param>
-    public record ProductCreateDto(string Title, string Description, decimal Price, string UserId, string[] Images, Condition Condition)
+    /// <param name="ProductCategoryId">The ID of the product category to which the product advert belongs</param>
+    public record ProductCreateDto(string Title, string Description, decimal Price, string UserId, string[] Images, Condition Condition, long? ProductCategoryId=null)
         : AdvertBaseCreateDto(Title, Description, Price, UserId)
     {
         /// <summary>
@@ -167,6 +168,7 @@ namespace EcoscolarWebApi.Utils.DTOs.Advert
             if (entity is PhysicalItems product)
             {
                 product.Condition = Condition;
+                product.ProductCategoryId = ProductCategoryId;
                 product.Pictures = Images.Select(url => new Pictures { Label = url }).ToList();
             }
         }
@@ -189,7 +191,7 @@ namespace EcoscolarWebApi.Utils.DTOs.Advert
     public record BookCreateDto(
         string Title, string Description, decimal Price, string UserId, string[] Images, Condition Condition,
         long CategoryId, string Isbn, string Author, string Publisher, string Edition, Language WrittenLanguage
-    ) : ProductCreateDto(Title, Description, Price, UserId, Images, Condition)
+    ) : ProductCreateDto(Title, Description, Price, UserId, Images, Condition, ProductCategoryId: null)
     {
         /// <summary>
         /// Converts the BookCreateDto to a Books entity.

--- a/EcoScolarWebApi/Utils/DTOs/Advert/AdvertDto.cs
+++ b/EcoScolarWebApi/Utils/DTOs/Advert/AdvertDto.cs
@@ -37,7 +37,7 @@ namespace EcoscolarWebApi.Utils.DTOs.Advert
                 Models.AdvertServices => "SERVICE",
                 _ => throw new InvalidOperationException("Unknown advert type")
             };
-
+            
             string? primaryImage = (entity as Models.PhysicalItems)?.Pictures?.FirstOrDefault()?.Label;
 
             return new AdvertReadDto(

--- a/EcoScolarWebApi/Utils/DTOs/AdvertDetailDto.cs
+++ b/EcoScolarWebApi/Utils/DTOs/AdvertDetailDto.cs
@@ -3,7 +3,6 @@ namespace EcoscolarWebApi.Utils.DTOs
 	public class AdvertDetailDto
 	{
 		public Guid Id { get; set; }
-		/// <summary>Même sémantique que <see cref="EcoscolarWebApi.Utils.DTOs.Advert.AdvertReadDto"/> <c>type</c>. Valeurs : <see cref="CatalogAdvertTypeCodes"/>.</summary>
 		public string Type { get; set; } = string.Empty;
 		public string Title { get; set; } = string.Empty;
 		public decimal Price { get; set; }

--- a/EcoScolarWebApi/Utils/DTOs/AdvertSearchQuery.cs
+++ b/EcoScolarWebApi/Utils/DTOs/AdvertSearchQuery.cs
@@ -1,5 +1,14 @@
 namespace EcoscolarWebApi.Utils.DTOs
 {
+    /// <summary>
+    /// Query parameters for advert search (summary list).
+    /// </summary>
+    /// <remarks>
+    /// For <c>GET api/v1/adverts/summary</c>, only <see cref="Q"/> and <see cref="Isbn"/> are honored by
+    /// <see cref="Services.AdvertSearchService"/> and <see cref="Services.FakeAdvertSearchService"/>.
+    /// <see cref="Category"/>, <see cref="MinPrice"/>, <see cref="MaxPrice"/>, <see cref="Subject"/>, and
+    /// <see cref="Grade"/> are reserved for future filtering and are currently ignored by the server.
+    /// </remarks>
     public class AdvertSearchQuery
     {
         public string? Q { get; set; }

--- a/EcoScolarWebApi/Utils/DTOs/AdvertSummaryDto.cs
+++ b/EcoScolarWebApi/Utils/DTOs/AdvertSummaryDto.cs
@@ -5,7 +5,6 @@ namespace EcoscolarWebApi.Utils.DTOs
 		public Guid Id { get; set; }
 		public string Title { get; set; } = string.Empty;
 		public decimal Price { get; set; }
-		/// <summary>Même sémantique que <see cref="EcoscolarWebApi.Utils.DTOs.Advert.AdvertReadDto"/> <c>type</c>. Valeurs : <see cref="CatalogAdvertTypeCodes"/>.</summary>
 		public string Type { get; set; } = string.Empty;
 		public string? Isbn { get; set; } = null;
 		public string? Category { get; set; }


### PR DESCRIPTION
## Summary

- Add optional **`q`** query parameter to **`GET /api/v1/adverts/services`** — case‑insensitive match on **title** and **description**.
- Subject / school‑level filtering is **out of scope** for this PR (sprint scope: **text search only**).

## Test plan

- `GET /api/v1/adverts/services` — returns all services.
- `GET /api/v1/adverts/services?q=<keyword>` — filters by title/description.