### PR TITLE
test(auth): suite complete login, profil, update et auth HTTP

### DIFF
--- a/EcoScolarWebApi.Tests/AuthControllerTests.cs
+++ b/EcoScolarWebApi.Tests/AuthControllerTests.cs
@@ -1,0 +1,53 @@
+using EcoScolarWebApi.Controllers;
+using EcoScolarWebApi.Models;
+using EcoScolarWebApi.Services.Contracts;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace EcoScolarWebApi.Tests.Controllers;
+
+public class AuthControllerTests
+{
+	private readonly IUserService _userServiceMock;
+	private readonly SignInManager<User> _signInManagerMock;
+	private readonly AuthController _controller;
+
+	public AuthControllerTests()
+	{
+		_userServiceMock = Substitute.For<IUserService>();
+
+		var userStore = Substitute.For<IUserStore<User>>();
+		var userManager = Substitute.For<UserManager<User>>(
+			userStore, null!, null!, null!, null!, null!, null!, null!, null!);
+
+		var contextAccessor = Substitute.For<IHttpContextAccessor>();
+		contextAccessor.HttpContext.Returns(new DefaultHttpContext());
+
+		_signInManagerMock = Substitute.For<SignInManager<User>>(
+			userManager,
+			contextAccessor,
+			Substitute.For<IUserClaimsPrincipalFactory<User>>(),
+			Substitute.For<IOptions<IdentityOptions>>(),
+			Substitute.For<ILogger<SignInManager<User>>>(),
+			Substitute.For<IAuthenticationSchemeProvider>(),
+			Substitute.For<IUserConfirmation<User>>());
+
+		_controller = new AuthController(_userServiceMock, _signInManagerMock);
+	}
+
+	[Fact]
+	public async Task Logout_CallsSignOutAndReturnsOk()
+	{
+		var result = await _controller.Logout();
+
+		await _signInManagerMock.Received(1).SignOutAsync();
+		result.Should().BeOfType<OkResult>();
+	}
+}

--- a/EcoScolarWebApi.Tests/Integration/AuthHttpIntegrationTests.cs
+++ b/EcoScolarWebApi.Tests/Integration/AuthHttpIntegrationTests.cs
@@ -1,0 +1,278 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using EcoScolarWebApi.DTOs.Users;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace EcoScolarWebApi.Tests.Integration;
+
+/// <summary>
+/// Tests HTTP auth complets : register, login (cookie HttpOnly + bearer), profil, update, logout.
+/// </summary>
+public class AuthHttpIntegrationTests : IClassFixture<AuthInMemoryWebApplicationFactory>
+{
+	private readonly AuthInMemoryWebApplicationFactory _factory;
+	private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+	public AuthHttpIntegrationTests(AuthInMemoryWebApplicationFactory factory) => _factory = factory;
+
+	private static string UniqueEmail(string prefix) => $"{prefix}.{Guid.NewGuid():N}@example.com";
+
+	private HttpClient CreateClient() => _factory.CreateCookieClient();
+
+	private static async Task RegisterAsync(HttpClient client, string email, string password = "Password123!")
+	{
+		var response = await client.PostAsJsonAsync("/api/v1/auth/register", new { email, password });
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+
+	[Fact]
+	public async Task Register_WithValidCredentials_CreatesUser()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("register");
+
+		await RegisterAsync(client, email);
+
+		await LoginWithCookiesAsync(client, email);
+		var profile = await GetProfileAsync(client);
+		profile.Email.Should().Be(email);
+	}
+
+	[Fact]
+	public async Task Register_WithDuplicateEmail_ReturnsBadRequest()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("duplicate");
+
+		await RegisterAsync(client, email);
+
+		var response = await client.PostAsJsonAsync("/api/v1/auth/register", new { email, password = "Password123!" });
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task Register_WithWeakPassword_ReturnsBadRequest()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("weak");
+
+		var response = await client.PostAsJsonAsync("/api/v1/auth/register", new { email, password = "123" });
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task Login_WithValidCredentials_SetsHttpOnlyAuthCookie()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("cookie");
+
+		await RegisterAsync(client, email);
+
+		using var request = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/login?useCookies=true")
+		{
+			Content = JsonContent.Create(new { email, password = "Password123!" })
+		};
+		var response = await client.SendAsync(request);
+
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		response.Headers.TryGetValues("Set-Cookie", out var cookies).Should().BeTrue();
+		cookies!.Should().Contain(c => c.Contains("Ecoscolar.Auth.Session", StringComparison.OrdinalIgnoreCase));
+		cookies.Should().Contain(c => c.Contains("httponly", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task Login_WithInvalidPassword_ReturnsUnauthorized()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("badpass");
+
+		await RegisterAsync(client, email);
+
+		var response = await client.PostAsJsonAsync("/api/v1/auth/login?useCookies=true", new { email, password = "WrongPassword!" });
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task Login_WithUnknownEmail_ReturnsUnauthorized()
+	{
+		var client = CreateClient();
+
+		var response = await client.PostAsJsonAsync("/api/v1/auth/login?useCookies=true", new
+		{
+			email = UniqueEmail("unknown"),
+			password = "Password123!"
+		});
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task GetMyProfile_WithoutAuth_ReturnsUnauthorized()
+	{
+		_factory.EnsureSeeded();
+		var client = _factory.CreateClient();
+
+		var response = await client.GetAsync("/api/v1/users/me");
+
+		response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task GetMyProfile_WithCookieAuth_ReturnsUserEmail()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("profile");
+
+		await RegisterAsync(client, email);
+		await LoginWithCookiesAsync(client, email);
+
+		var profile = await GetProfileAsync(client);
+
+		profile.Email.Should().Be(email);
+		profile.IsOnboarded.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task Login_WithBearerToken_AllowsAccessToProfile()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("bearer");
+
+		await RegisterAsync(client, email);
+
+		var tokenResponse = await client.PostAsJsonAsync("/api/v1/auth/login?useCookies=false", new { email, password = "Password123!" });
+		tokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var tokens = await tokenResponse.Content.ReadFromJsonAsync<BearerTokenResponse>(JsonOptions);
+		tokens.Should().NotBeNull();
+		tokens!.AccessToken.Should().NotBeNullOrWhiteSpace();
+		tokens.TokenType.Should().Be("Bearer");
+
+		var bearerClient = _factory.CreateClient();
+		_factory.EnsureSeeded();
+		bearerClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokens.AccessToken);
+
+		var profileResponse = await bearerClient.GetAsync("/api/v1/users/me");
+		profileResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var profile = await profileResponse.Content.ReadFromJsonAsync<UserReadDto>(JsonOptions);
+		profile!.Email.Should().Be(email);
+	}
+
+	[Fact]
+	public async Task UpdateProfile_WithCookieAuth_UpdatesUserAndSetsOnboarded()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("update");
+
+		await RegisterAsync(client, email);
+		await LoginWithCookiesAsync(client, email);
+
+		var updateDto = new UserUpdateDto(
+			Nickname: "eco_user",
+			FirstName: "Eco",
+			LastName: "Scolar",
+			PostalCode: "1000",
+			BirthdayDate: "2000-01-15",
+			SpokenLanguages: [new SpokenLanguageDto("FR", "Native")]
+		);
+
+		var response = await client.PutAsJsonAsync("/api/v1/users/me", updateDto);
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var updated = await response.Content.ReadFromJsonAsync<UserReadDto>(JsonOptions);
+		updated!.Nickname.Should().Be("eco_user");
+		updated.FirstName.Should().Be("Eco");
+		updated.LastName.Should().Be("Scolar");
+		updated.IsOnboarded.Should().BeTrue();
+		updated.Location!.PostalCode.Should().Be("1000");
+		updated.Location.City.Should().Be("Lausanne");
+		updated.SpokenLanguages.Should().ContainSingle(l => l.Language == "FR" && l.Level == "Native");
+	}
+
+	[Fact]
+	public async Task UpdateProfile_WithInvalidPostalCode_ReturnsBadRequest()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("badpostal");
+
+		await RegisterAsync(client, email);
+		await LoginWithCookiesAsync(client, email);
+
+		var updateDto = new UserUpdateDto(
+			Nickname: "user",
+			FirstName: "A",
+			LastName: "B",
+			PostalCode: "9999",
+			BirthdayDate: "2000-01-01",
+			SpokenLanguages: [new SpokenLanguageDto("FR", "Native")]
+		);
+
+		var response = await client.PutAsJsonAsync("/api/v1/users/me", updateDto);
+		response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+	}
+
+	[Fact]
+	public async Task Logout_WithCookieAuth_InvalidatesSession()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("logout");
+
+		await RegisterAsync(client, email);
+		await LoginWithCookiesAsync(client, email);
+
+		(await client.GetAsync("/api/v1/users/me")).StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var logoutResponse = await client.PostAsync("/api/v1/auth/logout", null);
+		logoutResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		(await client.GetAsync("/api/v1/users/me")).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+	}
+
+	[Fact]
+	public async Task GetPublicProfile_AfterOnboarding_ReturnsNickname()
+	{
+		var client = CreateClient();
+		var email = UniqueEmail("public");
+
+		await RegisterAsync(client, email);
+		await LoginWithCookiesAsync(client, email);
+
+		var updateDto = new UserUpdateDto(
+			Nickname: "public_nick",
+			FirstName: "Pub",
+			LastName: "Lic",
+			PostalCode: "1000",
+			BirthdayDate: "1999-05-05",
+			SpokenLanguages: [new SpokenLanguageDto("DE", "Fluent")]
+		);
+		await client.PutAsJsonAsync("/api/v1/users/me", updateDto);
+
+		var profile = await GetProfileAsync(client);
+
+		var publicResponse = await client.GetAsync($"/api/v1/users/{profile.Id}");
+		publicResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var publicProfile = await publicResponse.Content.ReadFromJsonAsync<UserPublicReadDto>(JsonOptions);
+		publicProfile!.Nickname.Should().Be("public_nick");
+	}
+
+	private static async Task LoginWithCookiesAsync(HttpClient client, string email, string password = "Password123!")
+	{
+		var response = await client.PostAsJsonAsync("/api/v1/auth/login?useCookies=true", new { email, password });
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+	}
+
+	private static async Task<UserReadDto> GetProfileAsync(HttpClient client)
+	{
+		var response = await client.GetAsync("/api/v1/users/me");
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+		return (await response.Content.ReadFromJsonAsync<UserReadDto>(JsonOptions))!;
+	}
+
+	private sealed record BearerTokenResponse(string TokenType, string AccessToken, int ExpiresIn, string RefreshToken);
+}

--- a/EcoScolarWebApi.Tests/Integration/AuthInMemoryWebApplicationFactory.cs
+++ b/EcoScolarWebApi.Tests/Integration/AuthInMemoryWebApplicationFactory.cs
@@ -1,0 +1,79 @@
+using EcoScolarWebApi.Data;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace EcoScolarWebApi.Tests.Integration;
+
+/// <summary>
+/// WebApplicationFactory avec EF InMemory pour tests HTTP auth (cookies + bearer).
+/// </summary>
+public class AuthInMemoryWebApplicationFactory : WebApplicationFactory<global::Program>
+{
+	private readonly string _keysPath = Path.Combine(Path.GetTempPath(), "ecoscolar-auth-tests", Guid.NewGuid().ToString("N"));
+	private bool _seeded;
+
+	protected override void ConfigureWebHost(IWebHostBuilder builder)
+	{
+		builder.UseEnvironment("Testing");
+
+		builder.ConfigureLogging(logging => logging.ClearProviders());
+
+		builder.ConfigureTestServices(services =>
+		{
+			Directory.CreateDirectory(_keysPath);
+
+			services.AddDataProtection()
+				.PersistKeysToFileSystem(new DirectoryInfo(_keysPath))
+				.SetApplicationName("EcoScolarAuthTests");
+
+			services.Configure<IdentityOptions>(options =>
+			{
+				options.SignIn.RequireConfirmedAccount = false;
+				options.User.RequireUniqueEmail = true;
+			});
+
+			services.ConfigureApplicationCookie(options =>
+			{
+				options.Cookie.Name = "Ecoscolar.Auth.Session";
+				options.Cookie.HttpOnly = true;
+				options.Cookie.SecurePolicy = CookieSecurePolicy.None;
+				options.Cookie.SameSite = SameSiteMode.Lax;
+			});
+		});
+	}
+
+	public void EnsureSeeded()
+	{
+		if (_seeded)
+			return;
+
+		using var scope = Services.CreateScope();
+		var db = scope.ServiceProvider.GetRequiredService<EcoscolarDbContext>();
+		db.Database.EnsureCreated();
+		IntegrationTestIdentityHelper.SeedLocations(db);
+		_seeded = true;
+	}
+
+	public HttpClient CreateCookieClient()
+	{
+		EnsureSeeded();
+		return CreateClient(new WebApplicationFactoryClientOptions { HandleCookies = true });
+	}
+
+	protected override void Dispose(bool disposing)
+	{
+		if (disposing && Directory.Exists(_keysPath))
+		{
+			try { Directory.Delete(_keysPath, recursive: true); } catch { /* best effort cleanup */ }
+		}
+
+		base.Dispose(disposing);
+	}
+}

--- a/EcoScolarWebApi.Tests/Integration/IntegrationTestIdentityHelper.cs
+++ b/EcoScolarWebApi.Tests/Integration/IntegrationTestIdentityHelper.cs
@@ -1,5 +1,6 @@
 using EcoScolarWebApi.Data;
 using EcoScolarWebApi.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,14 +21,33 @@ internal static class IntegrationTestIdentityHelper
 		services.AddAuthentication();
 		services.AddAuthorization();
 
-		// Même enregistrement Identity que la prod (AddAuthAndIdentity), sans la config cookie HTTPS.
 		services.AddIdentityApiEndpoints<User>()
 			.AddEntityFrameworkStores<EcoscolarDbContext>();
+
+		services.ConfigureApplicationCookie(options =>
+		{
+			options.Cookie.Name = "Ecoscolar.Auth.Session";
+			options.Cookie.HttpOnly = true;
+			options.Cookie.SecurePolicy = CookieSecurePolicy.None;
+		});
 
 		services.AddLogging();
 
 		var provider = services.BuildServiceProvider();
 		context = provider.GetRequiredService<EcoscolarDbContext>();
+		context.Database.EnsureCreated();
+		SeedLocations(context);
 		return provider;
+	}
+
+	internal static void SeedLocations(EcoscolarDbContext context)
+	{
+		if (context.Locations.Any())
+			return;
+
+		context.Locations.AddRange(
+			new Location { LocationId = 1, PostalCode = "1000", City = "Lausanne", Region = "Vaud" },
+			new Location { LocationId = 2, PostalCode = "1820", City = "Montreux", Region = "Vaud" });
+		context.SaveChanges();
 	}
 }

--- a/EcoScolarWebApi.Tests/Integration/LoginIntegrationTests.cs
+++ b/EcoScolarWebApi.Tests/Integration/LoginIntegrationTests.cs
@@ -56,6 +56,41 @@ public class LoginIntegrationTests : IDisposable
 		result.Succeeded.Should().BeFalse();
 	}
 
+	[Fact]
+	public async Task Login_WithUnknownEmail_UserNotFound()
+	{
+		var user = await _userManager.FindByEmailAsync("unknown@example.com");
+
+		user.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Register_StoresEmailCorrectly()
+	{
+		const string email = "register.store@example.com";
+		const string password = "Password123!";
+
+		(await _userManager.CreateAsync(new User { UserName = email, Email = email }, password))
+			.Succeeded.Should().BeTrue();
+
+		var stored = await _userManager.FindByEmailAsync(email);
+		stored.Should().NotBeNull();
+		stored!.Email.Should().Be(email);
+		stored.UserName.Should().Be(email);
+	}
+
+	[Fact]
+	public async Task Register_WithDuplicateEmail_Fails()
+	{
+		const string email = "duplicate@example.com";
+
+		(await _userManager.CreateAsync(new User { UserName = email, Email = email }, "Password123!"))
+			.Succeeded.Should().BeTrue();
+
+		var duplicate = await _userManager.CreateAsync(new User { UserName = email, Email = email }, "Password123!");
+		duplicate.Succeeded.Should().BeFalse();
+	}
+
 	public void Dispose()
 	{
 		_context.Database.EnsureDeleted();

--- a/EcoScolarWebApi.Tests/Integration/UserServiceIntegrationTests.cs
+++ b/EcoScolarWebApi.Tests/Integration/UserServiceIntegrationTests.cs
@@ -1,0 +1,157 @@
+using System.Security.Claims;
+using EcoScolarWebApi.Commun;
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.DTOs.Users;
+using EcoScolarWebApi.Models;
+using EcoScolarWebApi.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EcoScolarWebApi.Tests.Integration;
+
+/// <summary>
+/// Tests intégration UserService : profil, update, profil public.
+/// </summary>
+public class UserServiceIntegrationTests : IDisposable
+{
+	private readonly ServiceProvider _provider;
+	private readonly EcoscolarDbContext _context;
+	private readonly UserManager<User> _userManager;
+	private readonly UserService _userService;
+
+	public UserServiceIntegrationTests()
+	{
+		_provider = IntegrationTestIdentityHelper.CreateIdentityProvider(out _context);
+		_userManager = _provider.GetRequiredService<UserManager<User>>();
+		var signInManager = _provider.GetRequiredService<SignInManager<User>>();
+		_userService = new UserService(_userManager, _context, signInManager);
+	}
+
+	[Fact]
+	public async Task GetCurrentUserProfileAsync_ReturnsEmail_WhenUserExists()
+	{
+		const string email = "profile.service@example.com";
+		var user = await CreateUserAsync(email);
+		var principal = CreatePrincipal(user.Id);
+
+		var result = await _userService.GetCurrentUserProfileAsync(principal);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Data!.Email.Should().Be(email);
+	}
+
+	[Fact]
+	public async Task GetCurrentUserProfileAsync_ReturnsUnauthorized_WhenPrincipalIsEmpty()
+	{
+		var result = await _userService.GetCurrentUserProfileAsync(new ClaimsPrincipal());
+
+		result.IsSuccess.Should().BeFalse();
+		result.ErrorType.Should().Be(ErrorType.Unauthorized);
+	}
+
+	[Fact]
+	public async Task UpdateProfileAsync_SetsOnboardedAndLocation()
+	{
+		const string email = "update.service@example.com";
+		var user = await CreateUserAsync(email);
+		var principal = CreatePrincipal(user.Id);
+
+		var dto = new UserUpdateDto(
+			Nickname: "nick",
+			FirstName: "First",
+			LastName: "Last",
+			PostalCode: "1000",
+			BirthdayDate: "2001-06-01",
+			SpokenLanguages: [
+				new SpokenLanguageDto("FR", "Native"),
+				new SpokenLanguageDto("DE", "Intermediate")
+			]
+		);
+
+		var result = await _userService.UpdateProfileAsync(principal, dto);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Data!.Nickname.Should().Be("nick");
+		result.Data.FirstName.Should().Be("First");
+		result.Data.LastName.Should().Be("Last");
+		result.Data.IsOnboarded.Should().BeTrue();
+		result.Data.Location!.PostalCode.Should().Be("1000");
+		result.Data.SpokenLanguages.Should().HaveCount(2);
+
+		var reloaded = await _userManager.FindByEmailAsync(email);
+		reloaded!.IsOnboarded.Should().BeTrue();
+		reloaded.Nickname.Should().Be("nick");
+	}
+
+	[Fact]
+	public async Task UpdateProfileAsync_ReturnsBadRequest_WhenPostalCodeInvalid()
+	{
+		var user = await CreateUserAsync("invalid.postal@example.com");
+		var principal = CreatePrincipal(user.Id);
+
+		var dto = new UserUpdateDto(
+			Nickname: "nick",
+			FirstName: "A",
+			LastName: "B",
+			PostalCode: "0000",
+			BirthdayDate: "2000-01-01",
+			SpokenLanguages: [new SpokenLanguageDto("FR", "Native")]
+		);
+
+		var result = await _userService.UpdateProfileAsync(principal, dto);
+
+		result.IsSuccess.Should().BeFalse();
+		result.Errors.Should().Contain("Invalid postal code");
+	}
+
+	[Fact]
+	public async Task GetPublicProfileAsync_ReturnsNickname_WhenUserIsOnboarded()
+	{
+		var user = await CreateUserAsync("public.service@example.com");
+		var principal = CreatePrincipal(user.Id);
+
+		await _userService.UpdateProfileAsync(principal, new UserUpdateDto(
+			Nickname: "public_nick",
+			FirstName: "Pub",
+			LastName: "Lic",
+			PostalCode: "1820",
+			BirthdayDate: "1998-03-03",
+			SpokenLanguages: [new SpokenLanguageDto("IT", "Native")]
+		));
+
+		var result = await _userService.GetPublicProfileAsync(user.Id);
+
+		result.IsSuccess.Should().BeTrue();
+		result.Data!.Nickname.Should().Be("public_nick");
+	}
+
+	[Fact]
+	public async Task GetPublicProfileAsync_ReturnsNotFound_WhenUserNotOnboarded()
+	{
+		var user = await CreateUserAsync("not.onboarded@example.com");
+
+		var result = await _userService.GetPublicProfileAsync(user.Id);
+
+		result.IsSuccess.Should().BeFalse();
+		result.ErrorType.Should().Be(ErrorType.NotFound);
+	}
+
+	private async Task<User> CreateUserAsync(string email)
+	{
+		var user = new User { UserName = email, Email = email };
+		(await _userManager.CreateAsync(user, "Password123!")).Succeeded.Should().BeTrue();
+		return user;
+	}
+
+	private static ClaimsPrincipal CreatePrincipal(string userId) =>
+		new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, userId)], "TestAuth"));
+
+	public void Dispose()
+	{
+		_context.Database.EnsureDeleted();
+		_context.Dispose();
+		_provider.Dispose();
+	}
+}

--- a/EcoScolarWebApi.Tests/UserTest.cs
+++ b/EcoScolarWebApi.Tests/UserTest.cs
@@ -86,6 +86,101 @@ public class UsersControllerTests
 		okResult.Value.Should().BeEquivalentTo(userReadDto);
 	}
 
+	[Fact]
+	public async Task GetMyProfile_ShouldReturnUnauthorized_WhenSessionInvalid()
+	{
+		_userServiceMock.GetCurrentUserProfileAsync(Arg.Any<ClaimsPrincipal>())
+			.Returns(Result<UserReadDto>.Failure("Invalid session.", ErrorType.Unauthorized));
+
+		var result = await _controller.GetMyProfile();
+
+		result.Should().BeOfType<UnauthorizedObjectResult>();
+	}
+
+	#endregion
+
+	#region Tests pour UpdateFullProfile
+
+	[Fact]
+	public async Task UpdateFullProfile_ShouldReturnOk_WhenUpdateSucceeds()
+	{
+		var updatedDto = new UserReadDto(
+			"guid-update",
+			"nick",
+			"First",
+			"Last",
+			"update@example.com",
+			new LocationReadDto("1000", "Lausanne", "Vaud"),
+			"2000-01-01",
+			true,
+			[new SpokenLanguageDto("FR", "Native")]
+		);
+
+		_userServiceMock.UpdateProfileAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<UserUpdateDto>())
+			.Returns(Result<UserReadDto>.Success(updatedDto));
+
+		var result = await _controller.UpdateFullProfile(new UserUpdateDto(
+			"nick", "First", "Last", "1000", "2000-01-01",
+			[new SpokenLanguageDto("FR", "Native")]));
+
+		var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+		okResult.Value.Should().BeEquivalentTo(updatedDto);
+	}
+
+	[Fact]
+	public async Task UpdateFullProfile_ShouldReturnNotFound_WhenUserMissing()
+	{
+		_userServiceMock.UpdateProfileAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<UserUpdateDto>())
+			.Returns(Result<UserReadDto>.Failure("User not found", ErrorType.NotFound));
+
+		var result = await _controller.UpdateFullProfile(new UserUpdateDto(
+			"nick", "First", "Last", "1000", "2000-01-01",
+			[new SpokenLanguageDto("FR", "Native")]));
+
+		result.Should().BeOfType<NotFoundObjectResult>();
+	}
+
+	[Fact]
+	public async Task UpdateFullProfile_ShouldReturnBadRequest_WhenPostalCodeInvalid()
+	{
+		_userServiceMock.UpdateProfileAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<UserUpdateDto>())
+			.Returns(Result<UserReadDto>.Failure("Invalid postal code"));
+
+		var result = await _controller.UpdateFullProfile(new UserUpdateDto(
+			"nick", "First", "Last", "9999", "2000-01-01",
+			[new SpokenLanguageDto("FR", "Native")]));
+
+		result.Should().BeOfType<BadRequestObjectResult>();
+	}
+
+	#endregion
+
+	#region Tests pour GetUserProfile (public)
+
+	[Fact]
+	public async Task GetUserProfile_ShouldReturnOk_WhenProfileIsPublic()
+	{
+		var publicDto = new UserPublicReadDto("guid-public", "public_nick");
+		_userServiceMock.GetPublicProfileAsync("guid-public")
+			.Returns(Result<UserPublicReadDto>.Success(publicDto));
+
+		var result = await _controller.GetUserProfile("guid-public");
+
+		var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+		okResult.Value.Should().BeEquivalentTo(publicDto);
+	}
+
+	[Fact]
+	public async Task GetUserProfile_ShouldReturnNotFound_WhenProfileNotPublic()
+	{
+		_userServiceMock.GetPublicProfileAsync(Arg.Any<string>())
+			.Returns(Result<UserPublicReadDto>.Failure("User not found or profile is not public yet.", ErrorType.NotFound));
+
+		var result = await _controller.GetUserProfile("missing");
+
+		result.Should().BeOfType<NotFoundObjectResult>();
+	}
+
 	#endregion
 
 	#region Tests for GetMyFavorites

--- a/EcoScolarWebApi/EcoScolarWebApi.csproj
+++ b/EcoScolarWebApi/EcoScolarWebApi.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>

--- a/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
@@ -14,10 +14,18 @@ public static class ServiceCollectionExtensions
 {
 	public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration config)
 	{
-		var connectionString = config.GetConnectionString("Default")
-			?? throw new InvalidOperationException("Connection string 'Default' is missing.");
+		if (config.GetValue("UseInMemoryDatabase", defaultValue: false))
+		{
+			var databaseName = config.GetValue<string>("InMemoryDatabaseName") ?? Guid.NewGuid().ToString();
+			services.AddDbContext<EcoscolarDbContext>(options => options.UseInMemoryDatabase(databaseName));
+		}
+		else
+		{
+			var connectionString = config.GetConnectionString("Default")
+				?? throw new InvalidOperationException("Connection string 'Default' is missing.");
 
-		services.AddDbContext<EcoscolarDbContext>(options => options.UseSqlServer(connectionString));
+			services.AddDbContext<EcoscolarDbContext>(options => options.UseSqlServer(connectionString));
+		}
 
 		StripeConfiguration.ApiKey = config["Stripe:SecretKey"];
 

--- a/EcoScolarWebApi/Program.cs
+++ b/EcoScolarWebApi/Program.cs
@@ -33,7 +33,8 @@ if (app.Environment.IsDevelopment())
 	app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "EcoScolar Web API V1"));
 }
 
-app.UseHttpsRedirection();
+if (!app.Environment.IsEnvironment("Testing"))
+	app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/EcoScolarWebApi/appsettings.Testing.json
+++ b/EcoScolarWebApi/appsettings.Testing.json
@@ -1,0 +1,17 @@
+{
+  "UseInMemoryDatabase": true,
+  "InMemoryDatabaseName": "EcoScolarAuthTests",
+  "ApplyDatabaseMigrations": false,
+  "Stripe": {
+    "SecretKey": "sk_test_dummy"
+  },
+  "Features": {
+    "UseFakeAdvertSearch": true
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive authentication test suite (+29 tests, 99 total passing).

- **HTTP integration** (`AuthHttpIntegrationTests`) — register, login (HttpOnly cookie + Bearer token), profile, update, logout
- **Unit tests** — `AuthControllerTests` (logout), extended `UsersControllerTests` (GetMyProfile, UpdateFullProfile, GetUserProfile)
- **Service integration** — `UserServiceIntegrationTests`, extended `LoginIntegrationTests`
- **Test infrastructure** — `AuthInMemoryWebApplicationFactory`, `appsettings.Testing.json`, `UseInMemoryDatabase` flag (Testing env only)
- **Program.cs** — skip HTTPS redirection in Testing environment

## Test plan

- [ ] `dotnet test` — 99/99 pass
- [ ] `dotnet test --filter "FullyQualifiedName~AuthHttpIntegrationTests"` — 13 HTTP auth tests
- [ ] Verify CI passes