### PR TITLE
fix: use numeric advert id instead of guid

### DIFF
--- a/EcoScolarWebApi.Tests/AdvertTest.cs
+++ b/EcoScolarWebApi.Tests/AdvertTest.cs
@@ -1220,7 +1220,7 @@ public class AdvertsControllerTests : IDisposable
     {
         // Arrange
         var query = new AdvertSearchQuery { Q = "Math" };
-        var expectedSummaries = new List<AdvertSummaryDto> { new AdvertSummaryDto { Id = Guid.NewGuid() } };
+        var expectedSummaries = new List<AdvertSummaryDto> { new AdvertSummaryDto { Id = 1 } };
 
         _searchService.SearchSummariesAsync(query, Arg.Any<CancellationToken>())
             .Returns(expectedSummaries);
@@ -1239,7 +1239,7 @@ public class AdvertsControllerTests : IDisposable
     public async Task GetSummaryDetail_ReturnsOk_WhenItemExists()
     {
         // Arrange
-        var id = Guid.NewGuid();
+        var id = 42L;
         var expectedDetail = new AdvertDetailDto { Id = id };
 
         _searchService.GetDetailAsync(id, Arg.Any<CancellationToken>())
@@ -1257,7 +1257,7 @@ public class AdvertsControllerTests : IDisposable
     public async Task GetSummaryDetail_ReturnsNotFound_WhenItemDoesNotExist()
     {
         // Arrange
-        var id = Guid.NewGuid();
+        var id = 42L;
         _searchService.GetDetailAsync(id, Arg.Any<CancellationToken>())
             .Returns((AdvertDetailDto?)null);
 

--- a/EcoScolarWebApi/Controllers/AdvertsController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertsController.cs
@@ -297,10 +297,10 @@ public class AdvertsController : ControllerBase
 	}
 
 	/// <summary>
-	/// Mock catalogue detail by GUID (same dataset as /summary). GET api/v1/adverts/summary/{id}
+	/// Mock catalogue detail by id (same dataset as /summary). GET api/v1/adverts/summary/{id}
 	/// </summary>
-	[HttpGet("summary/{id:guid}")]
-	public async Task<IActionResult> GetSummaryDetail(Guid id, CancellationToken cancellationToken = default)
+	[HttpGet("summary/{id:long}")]
+	public async Task<IActionResult> GetSummaryDetail(long id, CancellationToken cancellationToken = default)
 	{
 		var detail = await _advertSearchService.GetDetailAsync(id, cancellationToken);
 		if (detail is null)

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertDetailDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertDetailDto.cs
@@ -2,7 +2,7 @@ namespace EcoScolarWebApi.DTOs.Adverts;
 
 public record AdvertDetailDto
 {
-	public Guid Id { get; set; }
+	public long Id { get; set; }
 	public string Type { get; set; } = string.Empty;
 	public string Title { get; set; } = string.Empty;
 	public decimal Price { get; set; }

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertSummaryDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertSummaryDto.cs
@@ -2,7 +2,7 @@ namespace EcoScolarWebApi.DTOs.Adverts;
 
 public record AdvertSummaryDto
 {
-	public Guid Id { get; set; }
+	public long Id { get; set; }
 	public string Title { get; set; } = string.Empty;
 	public decimal Price { get; set; }
 	public string Type { get; set; } = string.Empty;

--- a/EcoScolarWebApi/Services/AdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/AdvertSearchService.cs
@@ -10,7 +10,6 @@ namespace EcoScolarWebApi.Services;
 /// Catalogue summaries/detail sur <see cref="Advert"/> (livres, produits hors livre, services).
 /// Filtre <c>isbn</c> : lignes résolues comme annonces reliées à <see cref="Book"/>.
 /// Filtre <c>q</c> : titre ou ISBN (pour les lignes livre uniquement dans la sous-requête).
-/// <see cref="AdvertSummaryDto.Id"/> encode <see cref="Advert.AdvertId"/> en <see cref="Guid"/>.
 /// </summary>
 public sealed class AdvertSearchService : IAdvertSearchService
 {
@@ -78,36 +77,33 @@ public sealed class AdvertSearchService : IAdvertSearchService
 		return adverts.Select(a => MapSummary(a, booksDict, servicesDict)).ToList();
 	}
 
-	public async Task<AdvertDetailDto?> GetDetailAsync(Guid id, CancellationToken cancellationToken = default)
+	public async Task<AdvertDetailDto?> GetDetailAsync(long id, CancellationToken cancellationToken = default)
 	{
-		if (!TryAdvertIdFromCatalogGuid(id, out var advertId))
-			return null;
-
 		var bookDetail = await _context.Books
 			.AsNoTracking()
 			.Include(b => b.BookCategory)
 			.Include(b => b.Pictures)
-			.FirstOrDefaultAsync(b => b.AdvertId == advertId, cancellationToken);
+			.FirstOrDefaultAsync(b => b.AdvertId == id, cancellationToken);
 		if (bookDetail != null)
-			return ToDetailFromBook(bookDetail, id);
+			return ToDetailFromBook(bookDetail);
 
 		var serviceDetail = await _context.Services
 			.AsNoTracking()
 			.Include(s => s.Subject)
 			.Include(s => s.SchoolGrade)
-			.FirstOrDefaultAsync(s => s.AdvertId == advertId, cancellationToken);
+			.FirstOrDefaultAsync(s => s.AdvertId == id, cancellationToken);
 		if (serviceDetail != null)
-			return ToDetailFromService(serviceDetail, id);
+			return ToDetailFromService(serviceDetail);
 
 		var productDetail = await _context.Products
 			.AsNoTracking()
 			.Include(p => p.Pictures)
 			.Where(p =>
-				p.AdvertId == advertId
+				p.AdvertId == id
 				&& !_context.Set<Book>().Any(Books => Books.AdvertId == p.AdvertId))
 			.FirstOrDefaultAsync(cancellationToken);
 
-		return productDetail == null ? null : ToDetailFromPhysical(productDetail, id);
+		return productDetail == null ? null : ToDetailFromPhysical(productDetail);
 	}
 
 	private static AdvertSummaryDto MapSummary(
@@ -123,7 +119,7 @@ public sealed class AdvertSearchService : IAdvertSearchService
 					var src = fullBk ?? bk;
 					return new AdvertSummaryDto
 					{
-						Id = CatalogIdFromAdvertId(bk.AdvertId),
+						Id = bk.AdvertId,
 						Title = bk.Title,
 						Price = bk.Price,
 						Type = CatalogAdvertTypeCodes.Books,
@@ -139,7 +135,7 @@ public sealed class AdvertSearchService : IAdvertSearchService
 					var src = fullSvc ?? svc;
 					return new AdvertSummaryDto
 					{
-						Id = CatalogIdFromAdvertId(svc.AdvertId),
+						Id = svc.AdvertId,
 						Title = svc.Title,
 						Price = svc.Price,
 						Type = CatalogAdvertTypeCodes.Service,
@@ -152,7 +148,7 @@ public sealed class AdvertSearchService : IAdvertSearchService
 			case PhysicalItem phy when phy is not Book:
 				return new AdvertSummaryDto
 				{
-					Id = CatalogIdFromAdvertId(phy.AdvertId),
+					Id = phy.AdvertId,
 					Title = phy.Title,
 					Price = phy.Price,
 					Type = CatalogAdvertTypeCodes.Product,
@@ -166,13 +162,13 @@ public sealed class AdvertSearchService : IAdvertSearchService
 		}
 	}
 
-	private static AdvertDetailDto ToDetailFromBook(Book b, Guid catalogId)
+	private static AdvertDetailDto ToDetailFromBook(Book b)
 	{
 		string? imageUrl = b.Pictures?.FirstOrDefault()?.Label;
 
 		return new AdvertDetailDto
 		{
-			Id = catalogId,
+			Id = b.AdvertId,
 			Title = b.Title,
 			Type = CatalogAdvertTypeCodes.Books,
 			Isbn = string.IsNullOrWhiteSpace(b.ISBN) ? null : b.ISBN,
@@ -185,11 +181,11 @@ public sealed class AdvertSearchService : IAdvertSearchService
 		};
 	}
 
-	private static AdvertDetailDto ToDetailFromService(TutoringAdvert s, Guid catalogId)
+	private static AdvertDetailDto ToDetailFromService(TutoringAdvert s)
 	{
 		return new AdvertDetailDto
 		{
-			Id = catalogId,
+			Id = s.AdvertId,
 			Title = s.Title,
 			Type = CatalogAdvertTypeCodes.Service,
 			Isbn = null,
@@ -202,12 +198,12 @@ public sealed class AdvertSearchService : IAdvertSearchService
 		};
 	}
 
-	private static AdvertDetailDto ToDetailFromPhysical(PhysicalItem p, Guid catalogId)
+	private static AdvertDetailDto ToDetailFromPhysical(PhysicalItem p)
 	{
 		string? imageUrl = p.Pictures?.FirstOrDefault()?.Label;
 		return new AdvertDetailDto
 		{
-			Id = catalogId,
+			Id = p.AdvertId,
 			Title = p.Title,
 			Type = CatalogAdvertTypeCodes.Product,
 			Isbn = null,
@@ -218,27 +214,6 @@ public sealed class AdvertSearchService : IAdvertSearchService
 			Description = p.Description ?? string.Empty,
 			ImageUrl = imageUrl
 		};
-	}
-
-	private static Guid CatalogIdFromAdvertId(long advertId)
-	{
-		var bytes = new byte[16];
-		BitConverter.TryWriteBytes(bytes.AsSpan(), advertId);
-		return new Guid(bytes);
-	}
-
-	private static bool TryAdvertIdFromCatalogGuid(Guid catalogId, out long advertId)
-	{
-		var bytes = catalogId.ToByteArray();
-		advertId = 0;
-		for (var i = 8; i < 16; i++)
-		{
-			if (bytes[i] != 0)
-				return false;
-		}
-
-		advertId = BitConverter.ToInt64(bytes, 0);
-		return true;
 	}
 
 	private static string Normalize(string? isbnText)

--- a/EcoScolarWebApi/Services/Contracts/IAdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/Contracts/IAdvertSearchService.cs
@@ -5,5 +5,5 @@ namespace EcoScolarWebApi.Services.Contracts;
 public interface IAdvertSearchService
 {
     Task<IEnumerable<AdvertSummaryDto>> SearchSummariesAsync(AdvertSearchQuery? query, CancellationToken cancellationToken = default);
-    Task<AdvertDetailDto?> GetDetailAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<AdvertDetailDto?> GetDetailAsync(long id, CancellationToken cancellationToken = default);
 }

--- a/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
@@ -52,7 +52,7 @@ public class FakeAdvertSearchService : IAdvertSearchService
 		return Task.FromResult<IEnumerable<AdvertSummaryDto>>(result.ToList());
 	}
 
-	public Task<AdvertDetailDto?> GetDetailAsync(Guid id, CancellationToken cancellationToken = default)
+	public Task<AdvertDetailDto?> GetDetailAsync(long id, CancellationToken cancellationToken = default)
 	{
 		var entry = Catalog.FirstOrDefault(e => e.Summary.Id == id);
 		if (entry == null)
@@ -81,7 +81,7 @@ public class FakeAdvertSearchService : IAdvertSearchService
 		{
 			new(new AdvertSummaryDto
 			{
-				Id = Guid.Parse("6d4b9d4a-1dd1-4a38-8d68-7af4d9cb3c01"),
+				Id = 1,
 				Title = "Exemple annonce 1",
 				Price = 12.50m,
 				Type = CatalogAdvertTypeCodes.Books,
@@ -92,7 +92,7 @@ public class FakeAdvertSearchService : IAdvertSearchService
 			}, demoDesc),
 			new(new AdvertSummaryDto
 			{
-				Id = Guid.Parse("9a2d7d6e-8b4c-4d55-a901-2ec6f6c4d202"),
+				Id = 2,
 				Title = "Exemple annonce 2",
 				Price = 7.00m,
 				Type = CatalogAdvertTypeCodes.Books,
@@ -103,7 +103,7 @@ public class FakeAdvertSearchService : IAdvertSearchService
 			}, demoDesc),
 			new(new AdvertSummaryDto
 			{
-				Id = Guid.Parse("3f8e5c9b-2a7e-4f1a-9c3d-5b6e7f8a9c03"),
+				Id = 3,
 				Title = "Exemple annonce 3",
 				Price = 15.00m,
 				Type = CatalogAdvertTypeCodes.Books,
@@ -114,7 +114,7 @@ public class FakeAdvertSearchService : IAdvertSearchService
 			}, demoDesc),
 			new(new AdvertSummaryDto
 			{
-				Id = Guid.Parse("c4d8f2a1-6e9b-4c7d-a5f3-1e2d3c4b5a01"),
+				Id = 4,
 				Title = "Calculatrice scientifique Casio",
 				Price = 42.99m,
 				Type = CatalogAdvertTypeCodes.Product,
@@ -125,7 +125,7 @@ public class FakeAdvertSearchService : IAdvertSearchService
 			}, demoDesc),
 			new(new AdvertSummaryDto
 			{
-				Id = Guid.Parse("c4d8f2a1-6e9b-4c7d-a5f3-1e2d3c4b5a02"),
+				Id = 5,
 				Title = "Cartable à roulettes bleu marine",
 				Price = 59.90m,
 				Type = CatalogAdvertTypeCodes.Product,
@@ -136,7 +136,7 @@ public class FakeAdvertSearchService : IAdvertSearchService
 			}, demoDesc),
 			new(new AdvertSummaryDto
 			{
-				Id = Guid.Parse("e7b3c91d-5f44-4a8e-b2c6-9d8e7f6a5b03"),
+				Id = 6,
 				Title = "Cours particuliers mathématiques",
 				Price = 25.00m,
 				Type = CatalogAdvertTypeCodes.Service,
@@ -147,7 +147,7 @@ public class FakeAdvertSearchService : IAdvertSearchService
 			}, demoDesc),
 			new(new AdvertSummaryDto
 			{
-				Id = Guid.Parse("e7b3c91d-5f44-4a8e-b2c6-9d8e7f6a5b04"),
+				Id = 7,
 				Title = "Soutien physique chimie niveau lycée",
 				Price = 30.00m,
 				Type = CatalogAdvertTypeCodes.Service,


### PR DESCRIPTION
## Summary
- Use `long` AdvertId in catalog summary/detail DTOs instead of encoded Guids
- Simplify `AdvertSearchService` by removing Guid encode/decode helpers
- Update route to `GET /api/v1/adverts/summary/{id:long}` and align mock data + tests