### PR TITLE
Feature/advert qa

### DIFF
--- a/EcoScolarWebApi.Tests/AdvertQuestionsControllerTests.cs
+++ b/EcoScolarWebApi.Tests/AdvertQuestionsControllerTests.cs
@@ -1,0 +1,337 @@
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.DTOs.Adverts;
+using EcoScolarWebApi.Mappers;
+using EcoScolarWebApi.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using System.Security.Claims;
+using Xunit;
+
+namespace EcoScolarWebApi.Tests.Controllers;
+
+public class AdvertQuestionsControllerTests : IDisposable
+{
+	private readonly EcoscolarDbContext _context;
+	private readonly UserManager<User> _userManagerMock;
+	private readonly AdvertQuestionsController _controller;
+	private readonly PublicCommentMapper _mapper = new();
+
+	public AdvertQuestionsControllerTests()
+	{
+		var store = Substitute.For<IUserStore<User>>();
+		_userManagerMock = Substitute.For<UserManager<User>>(store, null!, null!, null!, null!, null!, null!, null!, null!);
+
+		var options = new DbContextOptionsBuilder<EcoscolarDbContext>()
+			.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+			.Options;
+
+		_context = new EcoscolarDbContext(options);
+		_controller = new AdvertQuestionsController(_context, _userManagerMock, _mapper)
+		{
+			ControllerContext = new ControllerContext
+			{
+				HttpContext = new DefaultHttpContext
+				{
+					User = new ClaimsPrincipal(new ClaimsIdentity())
+				}
+			}
+		};
+	}
+
+	public void Dispose()
+	{
+		_context.Database.EnsureDeleted();
+		_context.Dispose();
+	}
+
+	[Fact]
+	public async Task GetQuestions_ReturnsNotFound_WhenAdvertDoesNotExist()
+	{
+		var result = await _controller.GetQuestions(999);
+
+		result.Result.Should().BeOfType<NotFoundResult>();
+	}
+
+	[Fact]
+	public async Task GetQuestions_ReturnsQuestions_WhenAdvertExists()
+	{
+		var seller = new User { Id = "seller-1", UserName = "testuser", Email = "seller@test.ch" };
+		var commenter = new User { Id = "commenter-1", UserName = "userx", Email = "userx@test.ch" };
+		var advert = new TutoringAdvert
+		{
+			AdvertId = 1,
+			Title = "Cours de maths",
+			Description = "Test advert",
+			Price = 20,
+			Status = EcoScolarWebApi.Enums.AdvertStatus.ACTIVE,
+			CreatedAt = DateTime.UtcNow,
+			NotificationDate = DateTime.UtcNow.AddDays(7),
+			SellerId = seller.Id,
+			Seller = seller,
+			StudyLevel = "Lycée",
+			SubjectId = 1,
+			SchoolGradeId = 1,
+			TeachingLanguage = EcoScolarWebApi.Enums.LanguageEnum.FR
+		};
+
+		_context.Users.AddRange(seller, commenter);
+		_context.Adverts.Add(advert);
+		await _context.SaveChangesAsync();
+
+		var question = new PublicComment
+		{
+			CommentId = 1,
+			AdvertId = advert.AdvertId,
+			Advert = advert,
+			AuthorId = commenter.Id,
+			Author = commenter,
+			Content = "Est-ce disponible le week-end ?",
+			CreatedAt = DateTime.UtcNow.AddDays(-1)
+		};
+
+		_context.PublicComments.Add(question);
+		await _context.SaveChangesAsync();
+
+		var result = await _controller.GetQuestions(advert.AdvertId);
+
+		var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+		var questions = okResult.Value.Should().BeAssignableTo<IEnumerable<QuestionResponseDTO>>().Subject.ToList();
+
+		questions.Should().HaveCount(1);
+		questions[0].CommentId.Should().Be(1);
+		questions[0].AuthorId.Should().Be(commenter.Id);
+		questions[0].Author.Should().Be(commenter.UserName);
+		questions[0].Content.Should().Be("Est-ce disponible le week-end ?");
+	}
+
+	[Fact]
+	public async Task AskQuestion_ReturnsUnauthorized_WhenUserIsMissing()
+	{
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns((User?)null);
+
+		var result = await _controller.AskQuestion(1, new QuestionRequestDTO("Ma question"));
+
+		result.Result.Should().BeOfType<UnauthorizedResult>();
+	}
+
+	[Fact]
+	public async Task AskQuestion_ReturnsNotFound_WhenAdvertDoesNotExist()
+	{
+		var user = new User { Id = "user-1", UserName = "user1", Email = "user1@test.ch" };
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+
+		var result = await _controller.AskQuestion(1, new QuestionRequestDTO("Ma question"));
+
+		result.Result.Should().BeOfType<NotFoundResult>();
+	}
+
+	[Fact]
+	public async Task AskQuestion_CreatesQuestion_AndReturnsCreated()
+	{
+		var seller = new User { Id = "seller-1", UserName = "testuser", Email = "seller@test.ch" };
+		var asker = new User { Id = "user-1", UserName = "userx", Email = "userx@test.ch" };
+		var advert = new TutoringAdvert
+		{
+			AdvertId = 1,
+			Title = "Cours de maths",
+			Description = "Test advert",
+			Price = 20,
+			Status = EcoScolarWebApi.Enums.AdvertStatus.ACTIVE,
+			CreatedAt = DateTime.UtcNow,
+			NotificationDate = DateTime.UtcNow.AddDays(7),
+			SellerId = seller.Id,
+			Seller = seller,
+			StudyLevel = "Lycée",
+			SubjectId = 1,
+			SchoolGradeId = 1,
+			TeachingLanguage = EcoScolarWebApi.Enums.LanguageEnum.FR
+		};
+
+		_context.Users.AddRange(seller, asker);
+		_context.Adverts.Add(advert);
+		await _context.SaveChangesAsync();
+
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(asker);
+
+		var result = await _controller.AskQuestion(advert.AdvertId, new QuestionRequestDTO("Ma question"));
+
+		var created = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
+		var response = created.Value.Should().BeAssignableTo<QuestionResponseDTO>().Subject;
+
+		response.AuthorId.Should().Be(asker.Id);
+		response.Author.Should().Be(asker.UserName);
+		response.Content.Should().Be("Ma question");
+		response.Answer.Should().BeEmpty();
+		response.AnsweredAt.Should().BeNull();
+
+		_context.PublicComments.Should().HaveCount(1);
+		_context.PublicComments.Single().Content.Should().Be("Ma question");
+	}
+
+	[Fact]
+	public async Task AnswerQuestion_ReturnsUnauthorized_WhenUserIsMissing()
+	{
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns((User?)null);
+
+		var result = await _controller.AnswerQuestion(1, 1, new AnswerRequestDTO("Oui"));
+
+		result.Result.Should().BeOfType<UnauthorizedResult>();
+	}
+
+	[Fact]
+	public async Task AnswerQuestion_ReturnsNotFound_WhenQuestionDoesNotExist()
+	{
+		var seller = new User { Id = "seller-1", UserName = "testuser", Email = "seller@test.ch" };
+		_context.Users.Add(seller);
+		await _context.SaveChangesAsync();
+
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(seller);
+
+		var result = await _controller.AnswerQuestion(1, 99, new AnswerRequestDTO("Oui"));
+
+		result.Result.Should().BeOfType<NotFoundResult>();
+	}
+
+	[Fact]
+	public async Task AnswerQuestion_ReturnsForbid_WhenCallerIsNotSeller()
+	{
+		var seller = new User { Id = "seller-1", UserName = "testuser", Email = "seller@test.ch" };
+		var otherUser = new User { Id = "user-2", UserName = "user2", Email = "user2@test.ch" };
+		var advert = new TutoringAdvert
+		{
+			AdvertId = 1,
+			Title = "Cours de maths",
+			Description = "Test advert",
+			Price = 20,
+			Status = EcoScolarWebApi.Enums.AdvertStatus.ACTIVE,
+			CreatedAt = DateTime.UtcNow,
+			NotificationDate = DateTime.UtcNow.AddDays(7),
+			SellerId = seller.Id,
+			Seller = seller,
+			StudyLevel = "Lycée",
+			SubjectId = 1,
+			SchoolGradeId = 1,
+			TeachingLanguage = EcoScolarWebApi.Enums.LanguageEnum.FR
+		};
+		var question = new PublicComment
+		{
+			CommentId = 1,
+			AdvertId = advert.AdvertId,
+			Advert = advert,
+			AuthorId = otherUser.Id,
+			Author = otherUser,
+			Content = "Est-ce disponible ?",
+			CreatedAt = DateTime.UtcNow.AddDays(-1)
+		};
+
+		_context.Users.AddRange(seller, otherUser);
+		_context.Adverts.Add(advert);
+		_context.PublicComments.Add(question);
+		await _context.SaveChangesAsync();
+
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(otherUser);
+
+		var result = await _controller.AnswerQuestion(advert.AdvertId, question.CommentId, new AnswerRequestDTO("Oui"));
+
+		result.Result.Should().BeOfType<ForbidResult>();
+	}
+
+	[Fact]
+	public async Task AnswerQuestion_ReturnsBadRequest_WhenAnswerAlreadyExists()
+	{
+		var seller = new User { Id = "seller-1", UserName = "testuser", Email = "seller@test.ch" };
+		var advert = new TutoringAdvert
+		{
+			AdvertId = 1,
+			Title = "Cours de maths",
+			Description = "Test advert",
+			Price = 20,
+			Status = EcoScolarWebApi.Enums.AdvertStatus.ACTIVE,
+			CreatedAt = DateTime.UtcNow,
+			NotificationDate = DateTime.UtcNow.AddDays(7),
+			SellerId = seller.Id,
+			Seller = seller,
+			StudyLevel = "Lycée",
+			SubjectId = 1,
+			SchoolGradeId = 1,
+			TeachingLanguage = EcoScolarWebApi.Enums.LanguageEnum.FR
+		};
+		var question = new PublicComment
+		{
+			CommentId = 1,
+			AdvertId = advert.AdvertId,
+			Advert = advert,
+			AuthorId = "user-2",
+			Content = "Est-ce disponible ?",
+			Answer = "Oui",
+			AnsweredAt = DateTime.UtcNow.AddHours(-1),
+			CreatedAt = DateTime.UtcNow.AddDays(-1)
+		};
+
+		_context.Users.Add(seller);
+		_context.Adverts.Add(advert);
+		_context.PublicComments.Add(question);
+		await _context.SaveChangesAsync();
+
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(seller);
+
+		var result = await _controller.AnswerQuestion(advert.AdvertId, question.CommentId, new AnswerRequestDTO("Nouvelle réponse"));
+
+		var badRequest = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+		badRequest.Value.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task AnswerQuestion_ReturnsOk_AndStoresAnswer_WhenSellerReplies()
+	{
+		var seller = new User { Id = "seller-1", UserName = "testuser", Email = "seller@test.ch" };
+		var asker = new User { Id = "user-1", UserName = "userx", Email = "userx@test.ch" };
+		var advert = new TutoringAdvert
+		{
+			AdvertId = 1,
+			Title = "Cours de maths",
+			Description = "Test advert",
+			Price = 20,
+			Status = EcoScolarWebApi.Enums.AdvertStatus.ACTIVE,
+			CreatedAt = DateTime.UtcNow,
+			NotificationDate = DateTime.UtcNow.AddDays(7),
+			SellerId = seller.Id,
+			Seller = seller,
+			StudyLevel = "Lycée",
+			SubjectId = 1,
+			SchoolGradeId = 1,
+			TeachingLanguage = EcoScolarWebApi.Enums.LanguageEnum.FR
+		};
+		var question = new PublicComment
+		{
+			CommentId = 1,
+			AdvertId = advert.AdvertId,
+			Advert = advert,
+			AuthorId = asker.Id,
+			Author = asker,
+			Content = "Est-ce disponible ?",
+			CreatedAt = DateTime.UtcNow.AddDays(-1)
+		};
+
+		_context.Users.AddRange(seller, asker);
+		_context.Adverts.Add(advert);
+		_context.PublicComments.Add(question);
+		await _context.SaveChangesAsync();
+
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(seller);
+
+		var result = await _controller.AnswerQuestion(advert.AdvertId, question.CommentId, new AnswerRequestDTO("Oui, bien sûr"));
+
+		var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+		var response = okResult.Value.Should().BeAssignableTo<AnswerResponseDTO>().Subject;
+
+		response.Answer.Should().Be("Oui, bien sûr");
+		response.AnsweredAt.Should().NotBeNull();
+		_context.PublicComments.Single().Answer.Should().Be("Oui, bien sûr");
+		_context.PublicComments.Single().AnsweredAt.Should().NotBeNull();
+	}
+}

--- a/EcoScolarWebApi/Controllers/AdvertQuestionsController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertQuestionsController.cs
@@ -1,0 +1,79 @@
+
+using Asp.Versioning;
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.DTOs.Adverts;
+using EcoScolarWebApi.Mappers;
+using EcoScolarWebApi.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/adverts/{advertId}/questions")]
+[ApiController]
+[Authorize]
+public class AdvertQuestionsController(EcoscolarDbContext context, UserManager<User> userManager, PublicCommentMapper mapper) : Controller
+{
+	private readonly EcoscolarDbContext _context = context;
+	private readonly UserManager<User> _userManager = userManager;
+	private readonly PublicCommentMapper _mapper = mapper;
+
+	[HttpGet]
+	public async Task<ActionResult<IEnumerable<QuestionResponseDTO>>> GetQuestions(long advertId)
+	{
+		var advertExists = await _context.Adverts.AnyAsync(a => a.AdvertId == advertId);
+		if (!advertExists)
+			return NotFound();
+
+		var questions = await _mapper.ProjectToQuestionResponses(
+		_context.PublicComments.Where(q => q.AdvertId == advertId)).ToListAsync();
+
+		return Ok(questions);
+	}
+	[HttpPost]
+	public async Task<ActionResult<QuestionResponseDTO>> AskQuestion(long advertId, [FromBody] QuestionRequestDTO question)
+	{
+		var user = await _userManager.GetUserAsync(User);
+		if (user is null) return Unauthorized();
+
+		if (!await _context.Adverts.AnyAsync(a => a.AdvertId == advertId)) return NotFound();
+
+		var publicComment = new PublicComment
+		{
+			AdvertId = advertId,
+			Content = question.Content,
+			CreatedAt = DateTime.UtcNow,
+			AuthorId = user.Id,
+			Author = user
+		};
+
+		_context.PublicComments.Add(publicComment);
+		await _context.SaveChangesAsync();
+
+		return CreatedAtAction(nameof(GetQuestions), new { advertId }, _mapper.ToQuestionResponse(publicComment));
+	}
+	[HttpPost("{questionId}/answers")]
+	public async Task<ActionResult<QuestionResponseDTO>> AnswerQuestion(long advertId, long questionId, [FromBody] AnswerRequestDTO answer)
+	{
+		var user = await _userManager.GetUserAsync(User);
+		if (user is null) return Unauthorized();
+
+		var publicQuestion = await _context.PublicComments
+			.Include(q => q.Advert)
+			.FirstOrDefaultAsync(q => q.CommentId == questionId && q.AdvertId == advertId);
+
+		if (publicQuestion is null) return NotFound();
+		if (publicQuestion.Advert.SellerId != user.Id) return Forbid();
+
+		if (!string.IsNullOrWhiteSpace(publicQuestion.Answer))
+			return BadRequest(new { message = "An answer has already been posted for this question and cannot be modified." });
+
+		publicQuestion.Answer = answer.Content;
+		publicQuestion.AnsweredAt = DateTime.UtcNow;
+
+		await _context.SaveChangesAsync();
+
+		return Ok(_mapper.ToAnswerResponse(publicQuestion));
+	}
+}

--- a/EcoScolarWebApi/Controllers/SubjectsController.cs
+++ b/EcoScolarWebApi/Controllers/SubjectsController.cs
@@ -24,7 +24,7 @@ public class SubjectsController : ControllerBase
 
     // GET: api/v1/Subjects
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<SubjectResponse>>> GetSubjects()
+    public async Task<ActionResult<IEnumerable<SubjectResponseDTO>>> GetSubjects()
     {
         var subjects = await _context.Subjects.ToListAsync();
 
@@ -34,7 +34,7 @@ public class SubjectsController : ControllerBase
 
     // GET: api/v1/Subjects/5
     [HttpGet("{subjectid}")]
-    public async Task<ActionResult<SubjectResponse>> GetSubjects(long subjectid)
+    public async Task<ActionResult<SubjectResponseDTO>> GetSubjects(long subjectid)
     {
         var subject = await _context.Subjects.FindAsync(subjectid);
 
@@ -49,7 +49,7 @@ public class SubjectsController : ControllerBase
 
     // PUT: api/v1/Subjects/5
     [HttpPut("{subjectid}")]
-    public async Task<IActionResult> PutSubjects(long subjectid, SubjectRequest request)
+    public async Task<IActionResult> PutSubjects(long subjectid, SubjectRequestDTO request)
     {
         var existingSubject = await _context.Subjects.FindAsync(subjectid);
 
@@ -82,7 +82,7 @@ public class SubjectsController : ControllerBase
 
     // POST: api/v1/Subjects
     [HttpPost]
-    public async Task<ActionResult<SubjectResponse>> PostSubjects(SubjectRequest request)
+    public async Task<ActionResult<SubjectResponseDTO>> PostSubjects(SubjectRequestDTO request)
     {
         // Utilisation de Mapperly pour transformer la request en entité
         var subject = _mapper.ToEntity(request);

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertQuestionDTOs.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertQuestionDTOs.cs
@@ -5,17 +5,18 @@ namespace EcoScolarWebApi.DTOs.Adverts;
 // DTO to read a question and its answer (if any) for an advert
 public class QuestionResponseDTO
 {
+    public int CommentId { get; set; }
     public string AuthorId { get; set; } = string.Empty;
     public string Author { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
-    public AnswerResponseDTO? Answer { get; set; }
+    public string Answer { get; set; } = string.Empty;
+    public DateTime? AnsweredAt { get; set; }
 }
 
 // DTO to read an answer to a question for an advert
 public class AnswerResponseDTO
 {
-    public string Seller { get; set; } = string.Empty;
     public string Answer { get; set; } = string.Empty;
     public DateTime? AnsweredAt { get; set; }
 }

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertQuestionDTOs.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertQuestionDTOs.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace EcoScolarWebApi.DTOs.Adverts;
+
+// DTO to read a question and its answer (if any) for an advert
+public class QuestionResponseDTO
+{
+    public string AuthorId { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public AnswerResponseDTO? Answer { get; set; }
+}
+
+// DTO to read an answer to a question for an advert
+public class AnswerResponseDTO
+{
+    public string Seller { get; set; } = string.Empty;
+    public string Answer { get; set; } = string.Empty;
+    public DateTime? AnsweredAt { get; set; }
+}
+
+// DTO to create a new question for an advert
+public record QuestionRequestDTO([Required] string Content);
+
+// DTO to create a new answer to a question for an advert
+public record AnswerRequestDTO([Required] string Content);

--- a/EcoScolarWebApi/DTOs/ReferenceData/SubjectDTOs.cs
+++ b/EcoScolarWebApi/DTOs/ReferenceData/SubjectDTOs.cs
@@ -3,13 +3,13 @@
 namespace EcoScolarWebApi.DTOs.ReferenceData;
 
 // DTO to create or update a subject
-public record SubjectRequest(
+public record SubjectRequestDTO(
     [Required][StringLength(100)] string Name,
     [Required][StringLength(100)] string Code
 );
 
 // DTO to return subject data in responses
-public record SubjectResponse(
+public record SubjectResponseDTO(
     int SubjectId,
     string Name,
     string Code

--- a/EcoScolarWebApi/Data/DataSeeder.cs
+++ b/EcoScolarWebApi/Data/DataSeeder.cs
@@ -86,6 +86,7 @@ public class DataSeeder
 			.RuleFor(p => p.ProductCategoryId, f => f.Random.Bool(0.8f) ? f.Random.ListItem(productCategoryIds) : null);
 
 		var physicalItems = physicalItemsFaker.Generate(25);
+		physicalItems[0].SellerId = testUser.Id;
 
 		var booksFaker = new Faker<Book>("fr_CH")
 			.RuleFor(b => b.Title, f => $"Manuel de {f.Commerce.Department()}")
@@ -142,6 +143,34 @@ public class DataSeeder
         }
 
         context.Pictures.AddRange(pictures);
+        context.SaveChanges();
+
+        var publicComments = new List<PublicComment>
+        {
+            new()
+            {
+                AdvertId = physicalItems[0].AdvertId,
+                AuthorId = users[1].Id,
+                Content = "Peut-on récupérer l'objet rapidement ?",
+                CreatedAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new()
+            {
+                AdvertId = books.First().AdvertId,
+                AuthorId = users[2].Id,
+                Content = "Le manuel est-il encore en bon état ?",
+                CreatedAt = DateTime.UtcNow.AddDays(-2)
+            },
+            new()
+            {
+                AdvertId = physicalItems[0].AdvertId,
+                AuthorId = testUser.Id,
+                Content = "J'ai une question sur cet article de test.",
+                CreatedAt = DateTime.UtcNow.AddDays(-3)
+            }
+        };
+
+        context.PublicComments.AddRange(publicComments);
         context.SaveChanges();
     }
 }

--- a/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddMappersServices(this IServiceCollection services, IConfiguration config)
     {
         services.AddSingleton<SubjectMapper>();
+        services.AddSingleton<PublicCommentMapper>();
         return services;
     }
 

--- a/EcoScolarWebApi/Mappers/PublicCommentMapper.cs
+++ b/EcoScolarWebApi/Mappers/PublicCommentMapper.cs
@@ -1,0 +1,18 @@
+﻿using EcoScolarWebApi.DTOs.Adverts;
+using EcoScolarWebApi.Models;
+using Riok.Mapperly.Abstractions;
+
+namespace EcoScolarWebApi.Mappers;
+
+[Mapper]
+public partial class PublicCommentMapper
+{
+	[MapProperty(nameof(PublicComment.AuthorId), nameof(QuestionResponseDTO.AuthorId))]
+	[MapProperty("Author.UserName", nameof(QuestionResponseDTO.Author))]
+	public partial QuestionResponseDTO ToQuestionResponse(PublicComment comment);
+
+	[MapProperty("Advert.Seller.UserName", nameof(AnswerResponseDTO.Seller))]
+	[MapProperty(nameof(PublicComment.Answer), nameof(AnswerResponseDTO.Answer))]
+	[MapProperty(nameof(PublicComment.AnsweredAt), nameof(AnswerResponseDTO.AnsweredAt))]
+	public partial AnswerResponseDTO ToAnswerResponse(PublicComment comment);
+}

--- a/EcoScolarWebApi/Mappers/PublicCommentMapper.cs
+++ b/EcoScolarWebApi/Mappers/PublicCommentMapper.cs
@@ -7,12 +7,10 @@ namespace EcoScolarWebApi.Mappers;
 [Mapper]
 public partial class PublicCommentMapper
 {
-	[MapProperty(nameof(PublicComment.AuthorId), nameof(QuestionResponseDTO.AuthorId))]
 	[MapProperty("Author.UserName", nameof(QuestionResponseDTO.Author))]
 	public partial QuestionResponseDTO ToQuestionResponse(PublicComment comment);
 
-	[MapProperty("Advert.Seller.UserName", nameof(AnswerResponseDTO.Seller))]
-	[MapProperty(nameof(PublicComment.Answer), nameof(AnswerResponseDTO.Answer))]
-	[MapProperty(nameof(PublicComment.AnsweredAt), nameof(AnswerResponseDTO.AnsweredAt))]
 	public partial AnswerResponseDTO ToAnswerResponse(PublicComment comment);
+
+	public partial IQueryable<QuestionResponseDTO> ProjectToQuestionResponses(IQueryable<PublicComment> query);
 }

--- a/EcoScolarWebApi/Mappers/SubjectMapper.cs
+++ b/EcoScolarWebApi/Mappers/SubjectMapper.cs
@@ -7,11 +7,11 @@ namespace EcoScolarWebApi.Mappers;
 [Mapper]
 public partial class SubjectMapper
 {
-    public partial SubjectResponse ToResponse(Subject subject);
-    public partial IEnumerable<SubjectResponse> ToResponseList(IEnumerable<Subject> entities);
+    public partial SubjectResponseDTO ToResponse(Subject subject);
+    public partial IEnumerable<SubjectResponseDTO> ToResponseList(IEnumerable<Subject> entities);
 
     [MapperIgnoreTarget(nameof(Subject.SubjectId))]
-    public partial Subject ToEntity(SubjectRequest request);
+    public partial Subject ToEntity(SubjectRequestDTO request);
     [MapperIgnoreTarget(nameof(Subject.SubjectId))]
-    public partial void UpdateEntity(SubjectRequest request, Subject entity);
+    public partial void UpdateEntity(SubjectRequestDTO request, Subject entity);
 }

--- a/EcoScolarWebApi/Models/PublicComment.cs
+++ b/EcoScolarWebApi/Models/PublicComment.cs
@@ -25,13 +25,13 @@ public class PublicComment
     public long AdvertId { get; set; }
 
     [Required]
-    public string AuthorId { get; set; }
+    public string AuthorId { get; set; } = default!;
 
-    // === Navigation Properties ===
+	// === Navigation Properties ===
 
-    [ForeignKey(nameof(AdvertId))]
-    public virtual Advert? Advert { get; set; }
+	[ForeignKey(nameof(AdvertId))]
+    public virtual Advert Advert { get; set; } = default!;
 
     [ForeignKey(nameof(AuthorId))]
-    public virtual User? Author { get; set; }
+    public virtual User Author { get; set; } = default!;
 }


### PR DESCRIPTION
# Feature: Questions & Réponses Publiques

## Breaking Changes
Simplification des DTOs : La structure imbriquée prévue lors de la conception a été aplatie (Answer et AnsweredAt sont désormais au premier niveau de QuestionResponseDTO).

Cela permet d'optimiser les requêtes SQL et d'éviter des bugs de projection avec Entity Framework.

# Règles métier ajoutées
Seul le vendeur peut répondre à une question (403 Forbid).
Les réponses ne peuvent pas être modifiées une fois publiées (400 BadRequest).

Veuillez consulter le /swagger de l'API pour voir la nouvelle version des endpoints. 👯‍♂️ 