### PR TITLE
Bugfix/advert asks

### DIFF
--- a/EcoScolarWebApi.Tests/AdvertQuestionsControllerTests.cs
+++ b/EcoScolarWebApi.Tests/AdvertQuestionsControllerTests.cs
@@ -59,8 +59,8 @@ public class AdvertQuestionsControllerTests : IDisposable
 	[Fact]
 	public async Task GetQuestions_ReturnsQuestions_WhenAdvertExists()
 	{
-		var seller = new User { Id = "seller-1", UserName = "testuser", Email = "seller@test.ch" };
-		var commenter = new User { Id = "commenter-1", UserName = "userx", Email = "userx@test.ch" };
+		var seller = new User { Id = "seller-1", Nickname = "testuser", Email = "seller@test.ch" };
+		var commenter = new User { Id = "commenter-1", Nickname = "userx", Email = "userx@test.ch" };
 		var advert = new TutoringAdvert
 		{
 			AdvertId = 1,
@@ -104,7 +104,7 @@ public class AdvertQuestionsControllerTests : IDisposable
 		questions.Should().HaveCount(1);
 		questions[0].CommentId.Should().Be(1);
 		questions[0].AuthorId.Should().Be(commenter.Id);
-		questions[0].Author.Should().Be(commenter.UserName);
+		questions[0].Author.Should().Be(commenter.Nickname);
 		questions[0].Content.Should().Be("Est-ce disponible le week-end ?");
 	}
 
@@ -132,8 +132,8 @@ public class AdvertQuestionsControllerTests : IDisposable
 	[Fact]
 	public async Task AskQuestion_CreatesQuestion_AndReturnsCreated()
 	{
-		var seller = new User { Id = "seller-1", UserName = "testuser", Email = "seller@test.ch" };
-		var asker = new User { Id = "user-1", UserName = "userx", Email = "userx@test.ch" };
+		var seller = new User { Id = "seller-1", Nickname = "testuser", Email = "seller@test.ch" };
+		var asker = new User { Id = "user-1", Nickname = "userx", Email = "userx@test.ch" };
 		var advert = new TutoringAdvert
 		{
 			AdvertId = 1,
@@ -163,7 +163,7 @@ public class AdvertQuestionsControllerTests : IDisposable
 		var response = created.Value.Should().BeAssignableTo<QuestionResponseDTO>().Subject;
 
 		response.AuthorId.Should().Be(asker.Id);
-		response.Author.Should().Be(asker.UserName);
+		response.Author.Should().Be(asker.Nickname);	
 		response.Content.Should().Be("Ma question");
 		response.Answer.Should().BeEmpty();
 		response.AnsweredAt.Should().BeNull();
@@ -333,5 +333,37 @@ public class AdvertQuestionsControllerTests : IDisposable
 		response.AnsweredAt.Should().NotBeNull();
 		_context.PublicComments.Single().Answer.Should().Be("Oui, bien sûr");
 		_context.PublicComments.Single().AnsweredAt.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task AskQuestion_ReturnsForbid_WhenSellerAsksOwnAdvert()
+	{
+		var seller = new User { Id = "seller-3", UserName = "seller3", Email = "seller3@test.ch" };
+		var advert = new TutoringAdvert
+		{
+			AdvertId = 20,
+			Title = "Cours de physique",
+			Description = "Test advert",
+			Price = 30,
+			Status = EcoScolarWebApi.Enums.AdvertStatus.ACTIVE,
+			CreatedAt = DateTime.UtcNow,
+			NotificationDate = DateTime.UtcNow.AddDays(7),
+			SellerId = seller.Id,
+			Seller = seller,
+			StudyLevel = "Lycée",
+			SubjectId = 1,
+			SchoolGradeId = 1,
+			TeachingLanguage = EcoScolarWebApi.Enums.LanguageEnum.FR
+		};
+
+		_context.Users.Add(seller);
+		_context.Adverts.Add(advert);
+		await _context.SaveChangesAsync();
+
+		_userManagerMock.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(seller);
+
+		var result = await _controller.AskQuestion(advert.AdvertId, new QuestionRequestDTO("Self question"));
+
+		result.Result.Should().BeOfType<ForbidResult>();
 	}
 }

--- a/EcoScolarWebApi/Controllers/AdvertQuestionsController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertQuestionsController.cs
@@ -37,7 +37,11 @@ public class AdvertQuestionsController(EcoscolarDbContext context, UserManager<U
 		var user = await _userManager.GetUserAsync(User);
 		if (user is null) return Unauthorized();
 
-		if (!await _context.Adverts.AnyAsync(a => a.AdvertId == advertId)) return NotFound();
+		var advert = await _context.Adverts.FindAsync(advertId);
+		if (advert is null) return NotFound();
+
+		// Prevent the seller from asking a question on their own advert
+		if (advert.SellerId == user.Id) return Forbid();
 
 		var publicComment = new PublicComment
 		{

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertDto.cs
@@ -49,7 +49,7 @@ public record AdvertReadDto(long Id, string Type, string Title, decimal Price, D
 			NotificationDate: entity.NotificationDate,
 			Status: entity.Status,
 			UserId: entity.SellerId,
-			SellerPseudo: entity.Seller?.UserName ?? "Anonyme",
+			SellerPseudo: entity.Seller?.Nickname ?? "Anonyme",
 			PrimaryImage: primaryImage
 		);
 	}

--- a/EcoScolarWebApi/DTOs/Adverts/BookDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/BookDto.cs
@@ -17,7 +17,7 @@ public record BookReadDto(long id, string title, string description, decimal pri
 			notificationDate: entity.NotificationDate,
 			status: entity.Status,
 			userId: entity.SellerId,
-			sellerPseudo: entity.Seller?.UserName ?? "Anonyme",
+			sellerPseudo: entity.Seller?.Nickname ?? "Anonyme",
 			condition: entity.Condition,
 			weight: entity.Weight,
 			bookCategoryId: entity.BookCategoryId,

--- a/EcoScolarWebApi/DTOs/Adverts/ProductDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/ProductDto.cs
@@ -18,7 +18,7 @@ public record ProductReadDto(long Id, string Title, string Description, decimal 
 			NotificationDate: entity.NotificationDate,
 			Status: entity.Status,
 			UserId: entity.SellerId,
-			SellerPseudo: entity.Seller?.UserName ?? "Anonyme",
+			SellerPseudo: entity.Seller?.Nickname ?? "Anonyme",
 			Condition: entity.Condition,
 			Weight: entity.Weight ?? null,
 			ProductCategoryId: entity.ProductCategoryId ?? null,

--- a/EcoScolarWebApi/DTOs/Adverts/ServiceDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/ServiceDto.cs
@@ -17,7 +17,7 @@ public record ServiceReadDto(long Id, string Title, string Description, decimal 
 			NotificationDate: entity.NotificationDate,
 			Status: entity.Status,
 			UserId: entity.SellerId,
-			SellerPseudo: entity.Seller?.UserName ?? "Anonyme",
+			SellerPseudo: entity.Seller?.Nickname ?? "Anonyme",
 			SubjectId: entity.SubjectId,
 			SubjectLabel: entity.Subject.Name,
 			SchoolGradeId: entity.SchoolGradeId,

--- a/EcoScolarWebApi/Data/DataSeeder.cs
+++ b/EcoScolarWebApi/Data/DataSeeder.cs
@@ -40,6 +40,7 @@ public class DataSeeder
 			var user = new User
 			{
 				Id = Guid.NewGuid().ToString(),
+				Nickname = $"nick-{userName}",
 				UserName = userName,
 				Email = email,
 				EmailConfirmed = true,

--- a/EcoScolarWebApi/Mappers/PublicCommentMapper.cs
+++ b/EcoScolarWebApi/Mappers/PublicCommentMapper.cs
@@ -7,7 +7,7 @@ namespace EcoScolarWebApi.Mappers;
 [Mapper]
 public partial class PublicCommentMapper
 {
-	[MapProperty("Author.UserName", nameof(QuestionResponseDTO.Author))]
+	[MapProperty("Author.Nickname", nameof(QuestionResponseDTO.Author))]
 	public partial QuestionResponseDTO ToQuestionResponse(PublicComment comment);
 
 	public partial AnswerResponseDTO ToAnswerResponse(PublicComment comment);


### PR DESCRIPTION
# Correction utilisateur et affichage du nickname

- Correctif : Les vendeurs pouvaient par erreur poser des questions sur leurs propres annonces.

- Refactoring : Remplacement de username (qui stockait l'adresse e-mail) par nickname pour afficher le vrai pseudonyme de l'utilisateur.