### PR TITLE
fix: seed Swiss localities from CSV after migrations on startup

### DIFF
--- a/EcoScolarWebApi/Data/DataSeeder.cs
+++ b/EcoScolarWebApi/Data/DataSeeder.cs
@@ -16,7 +16,7 @@ public class DataSeeder
 	public static async Task Seed(EcoscolarDbContext context, UserManager<User> userManager, RoleManager<IdentityRole> roleManager)
 	{
 		// 1. Import Swiss localities from CSV (postal code + city + region)
-		await SeedLocationsAsync(context);
+		await SeedLocationsIfEmptyAsync(context);
 
 		if (await context.Users.AnyAsync())
 			return;
@@ -38,7 +38,10 @@ public class DataSeeder
 		await SeedRandomDataAsync(context, userManager);
 	}
 
-	private static async Task SeedLocationsAsync(EcoscolarDbContext context)
+	/// <summary>
+	/// Imports Swiss localities from CSV when the Location table is empty.
+	/// </summary>
+	public static async Task SeedLocationsIfEmptyAsync(EcoscolarDbContext context)
 	{
 		if (await context.Locations.AnyAsync())
 			return;

--- a/EcoScolarWebApi/Extensions/ApplicationBuilderExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ApplicationBuilderExtensions.cs
@@ -17,6 +17,19 @@ public static class ApplicationBuilderExtensions
 		}
 	}
 
+	/// <summary>
+	/// Seeds Swiss localities from switzerland_localities.csv when Location is empty (all envs except Testing).
+	/// </summary>
+	public static async Task SeedLocationsIfEmptyAsync(this WebApplication app)
+	{
+		if (app.Environment.IsEnvironment("Testing"))
+			return;
+
+		using var scope = app.Services.CreateScope();
+		var db = scope.ServiceProvider.GetRequiredService<EcoscolarDbContext>();
+		await DataSeeder.SeedLocationsIfEmptyAsync(db);
+	}
+
 	public static async Task SeedDatabaseInDevelopmentAsync(this WebApplication app)
 	{
 		if (app.Environment.IsDevelopment())

--- a/EcoScolarWebApi/Extensions/ApplicationBuilderExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ApplicationBuilderExtensions.cs
@@ -20,9 +20,12 @@ public static class ApplicationBuilderExtensions
 	/// <summary>
 	/// Seeds Swiss localities from switzerland_localities.csv when Location is empty (all envs except Testing).
 	/// </summary>
-	public static async Task SeedLocationsIfEmptyAsync(this WebApplication app)
+	public static async Task SeedLocationsIfEmptyAsync(this WebApplication app, IConfiguration config)
 	{
 		if (app.Environment.IsEnvironment("Testing"))
+			return;
+
+		if (!config.GetValue<bool>("ApplyDatabaseMigrations"))
 			return;
 
 		using var scope = app.Services.CreateScope();

--- a/EcoScolarWebApi/Program.cs
+++ b/EcoScolarWebApi/Program.cs
@@ -24,7 +24,7 @@ var app = builder.Build();
 
 // Migrations and seeding
 app.ApplyDatabaseMigrations(app.Configuration);
-await app.SeedLocationsIfEmptyAsync();
+await app.SeedLocationsIfEmptyAsync(app.Configuration);
 await app.SeedDatabaseInDevelopmentAsync();
 
 // Middleware configuration

--- a/EcoScolarWebApi/Program.cs
+++ b/EcoScolarWebApi/Program.cs
@@ -24,6 +24,7 @@ var app = builder.Build();
 
 // Migrations and seeding
 app.ApplyDatabaseMigrations(app.Configuration);
+await app.SeedLocationsIfEmptyAsync();
 await app.SeedDatabaseInDevelopmentAsync();
 
 // Middleware configuration


### PR DESCRIPTION
Import locations in all environments (not only Development) so Docker/Production
has a populated Location table after PR #78 CSV-based seeding.