### PR TITLE
fix: seed Identity roles (User, Admin) on startup in Docker

### DIFF
--- a/EcoScolarWebApi/Data/DataSeeder.cs
+++ b/EcoScolarWebApi/Data/DataSeeder.cs
@@ -18,14 +18,10 @@ public class DataSeeder
 		// 1. Import Swiss localities from CSV (postal code + city + region)
 		await SeedLocationsIfEmptyAsync(context);
 
+		await SeedIdentityRolesAsync(roleManager);
+
 		if (await context.Users.AnyAsync())
 			return;
-
-    if (!await roleManager.RoleExistsAsync("User"))
-        await roleManager.CreateAsync(new IdentityRole("User"));
-
-    if (!await roleManager.RoleExistsAsync("Admin"))
-        await roleManager.CreateAsync(new IdentityRole("Admin"));
 
     Randomizer.Seed = new Random(2025);
 		var faker = new Faker("fr_CH");
@@ -36,6 +32,15 @@ public class DataSeeder
 
 		// 3. Generate random data for more realistic testing
 		await SeedRandomDataAsync(context, userManager);
+	}
+
+	public static async Task SeedIdentityRolesAsync(RoleManager<IdentityRole> roleManager)
+	{
+		if (!await roleManager.RoleExistsAsync("User"))
+			await roleManager.CreateAsync(new IdentityRole("User"));
+
+		if (!await roleManager.RoleExistsAsync("Admin"))
+			await roleManager.CreateAsync(new IdentityRole("Admin"));
 	}
 
 	/// <summary>

--- a/EcoScolarWebApi/Extensions/ApplicationBuilderExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ApplicationBuilderExtensions.cs
@@ -18,13 +18,10 @@ public static class ApplicationBuilderExtensions
 	}
 
 	/// <summary>
-	/// Seeds Swiss localities from switzerland_localities.csv when Location is empty (all envs except Testing).
+	/// Seeds Swiss localities from switzerland_localities.csv when Location is empty.
 	/// </summary>
 	public static async Task SeedLocationsIfEmptyAsync(this WebApplication app, IConfiguration config)
 	{
-		if (app.Environment.IsEnvironment("Testing"))
-			return;
-
 		if (!config.GetValue<bool>("ApplyDatabaseMigrations"))
 			return;
 
@@ -35,9 +32,6 @@ public static class ApplicationBuilderExtensions
 
 	public static async Task SeedIdentityRolesAsync(this WebApplication app, IConfiguration config)
 	{
-		if (app.Environment.IsEnvironment("Testing"))
-			return;
-
 		if (!config.GetValue<bool>("ApplyDatabaseMigrations"))
 			return;
 

--- a/EcoScolarWebApi/Extensions/ApplicationBuilderExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ApplicationBuilderExtensions.cs
@@ -33,6 +33,19 @@ public static class ApplicationBuilderExtensions
 		await DataSeeder.SeedLocationsIfEmptyAsync(db);
 	}
 
+	public static async Task SeedIdentityRolesAsync(this WebApplication app, IConfiguration config)
+	{
+		if (app.Environment.IsEnvironment("Testing"))
+			return;
+
+		if (!config.GetValue<bool>("ApplyDatabaseMigrations"))
+			return;
+
+		using var scope = app.Services.CreateScope();
+		var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+		await DataSeeder.SeedIdentityRolesAsync(roleManager);
+	}
+
 	public static async Task SeedDatabaseInDevelopmentAsync(this WebApplication app)
 	{
 		if (app.Environment.IsDevelopment())

--- a/EcoScolarWebApi/Program.cs
+++ b/EcoScolarWebApi/Program.cs
@@ -25,6 +25,7 @@ var app = builder.Build();
 // Migrations and seeding
 app.ApplyDatabaseMigrations(app.Configuration);
 await app.SeedLocationsIfEmptyAsync(app.Configuration);
+await app.SeedIdentityRolesAsync(app.Configuration);
 await app.SeedDatabaseInDevelopmentAsync();
 
 // Middleware configuration


### PR DESCRIPTION
Roles were only created by DataSeeder in Development, causing 500
(Role USER does not exist) when completing registration in Production.