### PR TITLE
feat: add matched search alerts flow

### DIFF
--- a/EcoScolarWebApi/Controllers/UsersController.cs
+++ b/EcoScolarWebApi/Controllers/UsersController.cs
@@ -108,34 +108,29 @@ public class UsersController(IUserService userService, UserManager<User> userMan
 
 		if (!dto.HasAnyCriterion())
 			return BadRequest(new { message = "At least one search criterion is required." });
-
-		long? subjectId = null;
-		if (!string.IsNullOrWhiteSpace(dto.Subjects))
-		{
-			var subject = await _context.Subjects
-				.FirstOrDefaultAsync(s => s.Name == dto.Subjects.Trim());
-			subjectId = subject?.SubjectId;
-		}
-		long? bookCategoryId = null;
-		if (!string.IsNullOrWhiteSpace(dto.Category))
-		{
-			var category = await _context.BookCategories
-				.FirstOrDefaultAsync(c => c.Name == dto.Category.Trim());
-			bookCategoryId = category?.BookCategoryId;
-		}
 	
 		var alert = new SearchAlert
 		{
 			UserId = currentUser.Id,
 			AdvertSearch = dto.Q?.Trim() ?? string.Empty,
-			AdvertType = ResolveAdvertType(dto),
+			AdvertType = dto.AdvertType ?? ResolveAdvertType(dto),
 			ISBN = dto.Isbn?.Trim(),
+			BookCategoryId = dto.BookCategoryId,
+			ProductCategoryId = dto.ProductCategoryId,
+			SubjectId = dto.SubjectId,
+			SchoolGradeId = dto.SchoolGradeId,
+			MinPrice = dto.MinPrice,
 			MaxPrice = dto.MaxPrice,
-			SubjectId = subjectId,
-			BookCategoryId = bookCategoryId
+			CreatedAt = DateTime.UtcNow
 		};
 		_context.SearchAlerts.Add(alert);
 		await _context.SaveChangesAsync();
+
+		await _context.Entry(alert).Reference(a => a.BookCategory).LoadAsync();
+		await _context.Entry(alert).Reference(a => a.ProductCategory).LoadAsync();
+		await _context.Entry(alert).Reference(a => a.Subject).LoadAsync();
+		await _context.Entry(alert).Reference(a => a.SchoolGrade).LoadAsync();
+
 
 		return StatusCode(StatusCodes.Status201Created, SearchAlertReadDto.FromEntity(alert));
 	}
@@ -151,10 +146,21 @@ public class UsersController(IUserService userService, UserManager<User> userMan
 		if (currentUser == null)
 			return NotFound(new { message = "Seller not found." });
 		var alerts = await _context.SearchAlerts
+			.Include(a => a.BookCategory)
+			.Include(a => a.ProductCategory)
+			.Include(a => a.Subject)
+			.Include(a => a.SchoolGrade)
 			.Where(a => a.UserId == currentUser.Id)
 			.OrderByDescending(a => a.ResearchId)
 			.ToListAsync();
-		return Ok(alerts.Select(SearchAlertReadDto.FromEntity));
+
+		var result = alerts.Select(alert =>
+		{
+			var matchedCount = CountMatches(alert);
+			return SearchAlertReadDto.FromEntity(alert, matchedCount);
+		});
+
+		return Ok(result);
 	}
 
 	/// <summary>
@@ -240,7 +246,7 @@ public class UsersController(IUserService userService, UserManager<User> userMan
 		var favorites = await _context.UserFavorites
 			.Where(uf => uf.UserId == currentUser.Id)
 			.Include(uf => uf.Advert)
-			.ThenInclude(a => a.Seller)
+			.ThenInclude(a => a!.Seller)
 			.Select(uf => uf.Advert)
 			.ToListAsync();
 
@@ -253,7 +259,9 @@ public class UsersController(IUserService userService, UserManager<User> userMan
 				.LoadAsync();
 		}
 
-		return Ok(favorites.Select(AdvertReadDto.FromEntity));
+		return Ok(favorites
+			.Where(a => a != null)
+			.Select(a => AdvertReadDto.FromEntity(a!)));
 	}
 
 	/// <summary>
@@ -302,17 +310,155 @@ public class UsersController(IUserService userService, UserManager<User> userMan
 
 	private static string ResolveAdvertType(CreateSearchAlertDto dto)
 	{
-		if (!string.IsNullOrWhiteSpace(dto.Isbn))
+		if (!string.IsNullOrWhiteSpace(dto.Isbn) || dto.BookCategoryId.HasValue)
 			return CatalogAdvertTypeCodes.Books;
 
-		if (!string.IsNullOrWhiteSpace(dto.Subjects) || !string.IsNullOrWhiteSpace(dto.Grade))
+		if (dto.SubjectId.HasValue || dto.SchoolGradeId.HasValue)
 			return CatalogAdvertTypeCodes.Service;
 
-		if (!string.IsNullOrWhiteSpace(dto.Category))
+		if (dto.ProductCategoryId.HasValue)
 			return CatalogAdvertTypeCodes.Product;
 
 		return CatalogAdvertTypeCodes.Books;
 	}
+
+		private int CountMatches(SearchAlert alert)
+		{
+			return alert.AdvertType switch
+			{
+				CatalogAdvertTypeCodes.Books => CountBookMatches(alert),
+				CatalogAdvertTypeCodes.Product => CountProductMatches(alert),
+				CatalogAdvertTypeCodes.Service => CountServiceMatches(alert),
+				_ => CountAdvertMatches(alert)
+			};
+		}
+
+		private int CountAdvertMatches(SearchAlert alert)
+		{
+			var query = _context.Adverts.AsQueryable();
+
+			if (!string.IsNullOrWhiteSpace(alert.AdvertSearch))
+			{
+				var search = alert.AdvertSearch.Trim();
+				query = query.Where(a =>
+					EF.Functions.Like(a.Title, $"%{search}%")
+					|| EF.Functions.Like(a.Description, $"%{search}%"));
+			}
+
+			if (alert.MinPrice.HasValue)
+			{
+				query = query.Where(a => a.Price >= alert.MinPrice.Value);
+			}
+
+			if (alert.MaxPrice.HasValue)
+			{
+				query = query.Where(a => a.Price <= alert.MaxPrice.Value);
+			}
+
+			return query.Count();
+		}
+
+		private int CountBookMatches(SearchAlert alert)
+		{
+			var query = _context.Books.AsQueryable();
+
+			if (!string.IsNullOrWhiteSpace(alert.AdvertSearch))
+			{
+				var search = alert.AdvertSearch.Trim();
+				query = query.Where(b =>
+					EF.Functions.Like(b.Title, $"%{search}%")
+					|| EF.Functions.Like(b.Description, $"%{search}%"));
+			}
+
+			if (!string.IsNullOrWhiteSpace(alert.ISBN))
+			{
+				var isbn = alert.ISBN.Trim();
+				query = query.Where(b => EF.Functions.Like(b.ISBN, $"%{isbn}%"));
+			}
+
+			if (alert.BookCategoryId.HasValue)
+			{
+				query = query.Where(b => b.BookCategoryId == alert.BookCategoryId.Value);
+			}
+
+			if (alert.MinPrice.HasValue)
+			{
+				query = query.Where(b => b.Price >= alert.MinPrice.Value);
+			}
+
+			if (alert.MaxPrice.HasValue)
+			{
+				query = query.Where(b => b.Price <= alert.MaxPrice.Value);
+			}
+
+			return query.Count();
+		}
+		
+		private int CountProductMatches(SearchAlert alert)
+		{
+			var query = _context.Products
+				.Where(p => !_context.Books.Any(b => b.AdvertId == p.AdvertId));
+
+			if (!string.IsNullOrWhiteSpace(alert.AdvertSearch))
+			{
+				var search = alert.AdvertSearch.Trim();
+				query = query.Where(p =>
+					EF.Functions.Like(p.Title, $"%{search}%")
+					|| EF.Functions.Like(p.Description, $"%{search}%"));
+			}
+
+			if (alert.ProductCategoryId.HasValue)
+			{
+				query = query.Where(p => p.ProductCategoryId == alert.ProductCategoryId.Value);
+			}
+
+			if (alert.MinPrice.HasValue)
+			{
+				query = query.Where(p => p.Price >= alert.MinPrice.Value);
+			}
+
+			if (alert.MaxPrice.HasValue)
+			{
+				query = query.Where(p => p.Price <= alert.MaxPrice.Value);
+			}
+
+			return query.Count();
+		}
+
+		private int CountServiceMatches(SearchAlert alert)
+		{
+			var query = _context.Services.AsQueryable();
+
+			if (!string.IsNullOrWhiteSpace(alert.AdvertSearch))
+			{
+				var search = alert.AdvertSearch.Trim();
+				query = query.Where(s =>
+					EF.Functions.Like(s.Title, $"%{search}%")
+					|| EF.Functions.Like(s.Description, $"%{search}%"));
+			}
+
+			if (alert.SubjectId.HasValue)
+			{
+				query = query.Where(s => s.SubjectId == alert.SubjectId.Value);
+			}
+
+			if (alert.SchoolGradeId.HasValue)
+			{
+				query = query.Where(s => s.SchoolGradeId == alert.SchoolGradeId.Value);
+			}
+
+			if (alert.MinPrice.HasValue)
+			{
+				query = query.Where(s => s.Price >= alert.MinPrice.Value);
+			}
+
+			if (alert.MaxPrice.HasValue)
+			{
+				query = query.Where(s => s.Price <= alert.MaxPrice.Value);
+			}
+
+			return query.Count();
+		}
   #endregion
 
 	#region Reviews

--- a/EcoScolarWebApi/DTOs/Users/SearchAlertDto.cs
+++ b/EcoScolarWebApi/DTOs/Users/SearchAlertDto.cs
@@ -5,44 +5,61 @@ namespace EcoScolarWebApi.DTOs.Users;
 public record SearchAlertReadDto(
     int Id,
     string? Q,
+    string? AdvertType,
     string? Isbn,
-    string? Category,
+    long? BookCategoryId,
+    string? BookCategory,
+    long? ProductCategoryId,
+    string? ProductCategory,
+    long? SubjectId,
+    string? Subject,
+    long? SchoolGradeId,
+    string? Grade,
     decimal? MinPrice,
     decimal? MaxPrice,
-    string? Subjects,
-    string? Grade,
+    int MatchedCount,
     DateTime CreatedAt
 )
 {
-    public static SearchAlertReadDto FromEntity(SearchAlert entity) => new(
+    public static SearchAlertReadDto FromEntity(SearchAlert entity, int matchedCount=0) => new(
         Id: entity.ResearchId,
         Q: string.IsNullOrWhiteSpace(entity.AdvertSearch) ? null : entity.AdvertSearch,
+        AdvertType: entity.AdvertType,
         Isbn: entity.ISBN,
-        Category: entity.BookCategory?.Name,
-        MinPrice: null,
+        BookCategoryId: entity.BookCategoryId,
+        BookCategory: entity.BookCategory?.Name,
+        ProductCategoryId: entity.ProductCategoryId,
+        ProductCategory: entity.ProductCategory?.Name,
+        SubjectId: entity.SubjectId,
+        Subject: entity.Subject?.Name,
+        SchoolGradeId: entity.SchoolGradeId,
+        Grade: entity.SchoolGrade?.Name,
+        MinPrice: entity.MinPrice,
         MaxPrice: entity.MaxPrice,
-        Subjects: entity.Subject?.Name,
-        Grade: null,
-        CreatedAt: DateTime.UtcNow
+        MatchedCount: matchedCount,
+        CreatedAt: entity.CreatedAt
     );
 }
 
 public class CreateSearchAlertDto
 {
     public string? Q { get; set; }
+    public string? AdvertType { get; set; }
     public string? Isbn { get; set; }
-    public string? Category { get; set; }
+    public long? BookCategoryId { get; set; }
+    public long? ProductCategoryId { get; set; }
+    public long? SubjectId { get; set; }
+    public long? SchoolGradeId { get; set; }
     public decimal? MinPrice { get; set; }
     public decimal? MaxPrice { get; set; }
-    public string? Subjects { get; set; }
-    public string? Grade { get; set; }
 
     public bool HasAnyCriterion() =>
         !string.IsNullOrWhiteSpace(Q)
         || !string.IsNullOrWhiteSpace(Isbn)
-        || !string.IsNullOrWhiteSpace(Category)
-        || !string.IsNullOrWhiteSpace(Subjects)
-        || !string.IsNullOrWhiteSpace(Grade)
+        || BookCategoryId.HasValue
+        || ProductCategoryId.HasValue
+        || SubjectId.HasValue
+        || SchoolGradeId.HasValue
         || MinPrice.HasValue
         || MaxPrice.HasValue;
 }

--- a/EcoScolarWebApi/Migrations/20260609182052_AddSearchAlertFilterFields.Designer.cs
+++ b/EcoScolarWebApi/Migrations/20260609182052_AddSearchAlertFilterFields.Designer.cs
@@ -4,6 +4,7 @@ using EcoScolarWebApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EcoScolarWebApi.Migrations
 {
     [DbContext(typeof(EcoscolarDbContext))]
-    partial class EcoscolarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609182052_AddSearchAlertFilterFields")]
+    partial class AddSearchAlertFilterFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EcoScolarWebApi/Migrations/20260609182052_AddSearchAlertFilterFields.cs
+++ b/EcoScolarWebApi/Migrations/20260609182052_AddSearchAlertFilterFields.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoScolarWebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSearchAlertFilterFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "SearchAlerts",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "MinPrice",
+                table: "SearchAlerts",
+                type: "decimal(18,2)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "ProductCategoryId",
+                table: "SearchAlerts",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "SchoolGradeId",
+                table: "SearchAlerts",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SearchAlerts_ProductCategoryId",
+                table: "SearchAlerts",
+                column: "ProductCategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SearchAlerts_SchoolGradeId",
+                table: "SearchAlerts",
+                column: "SchoolGradeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SearchAlerts_ProductCategories_ProductCategoryId",
+                table: "SearchAlerts",
+                column: "ProductCategoryId",
+                principalTable: "ProductCategories",
+                principalColumn: "ProductCategoryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SearchAlerts_SchoolGrades_SchoolGradeId",
+                table: "SearchAlerts",
+                column: "SchoolGradeId",
+                principalTable: "SchoolGrades",
+                principalColumn: "SchoolGradeId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SearchAlerts_ProductCategories_ProductCategoryId",
+                table: "SearchAlerts");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SearchAlerts_SchoolGrades_SchoolGradeId",
+                table: "SearchAlerts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SearchAlerts_ProductCategoryId",
+                table: "SearchAlerts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SearchAlerts_SchoolGradeId",
+                table: "SearchAlerts");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "SearchAlerts");
+
+            migrationBuilder.DropColumn(
+                name: "MinPrice",
+                table: "SearchAlerts");
+
+            migrationBuilder.DropColumn(
+                name: "ProductCategoryId",
+                table: "SearchAlerts");
+
+            migrationBuilder.DropColumn(
+                name: "SchoolGradeId",
+                table: "SearchAlerts");
+        }
+    }
+}

--- a/EcoScolarWebApi/Models/SearchAlert.cs
+++ b/EcoScolarWebApi/Models/SearchAlert.cs
@@ -20,6 +20,16 @@ public class SearchAlert
 
     public string? ISBN { get; set; }
 
+    public long? ProductCategoryId { get; set; }
+
+    public long? SchoolGradeId { get; set; }
+
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal? MinPrice { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
     // === Foreign Keys ===
 
     public long? SubjectId { get; set; } 
@@ -27,7 +37,7 @@ public class SearchAlert
     public long? BookCategoryId { get; set; }
 
     [Required]
-    public string UserId { get; set; }
+    public string UserId { get; set; } = string.Empty;
 
     // === Navigation Properties ===
 
@@ -39,4 +49,10 @@ public class SearchAlert
 
     [ForeignKey(nameof(UserId))]
     public virtual User? User { get; set; }
+
+    [ForeignKey(nameof(ProductCategoryId))]
+    public virtual ProductCategory? ProductCategory { get; set; }
+
+    [ForeignKey(nameof(SchoolGradeId))]
+    public virtual SchoolGrade? SchoolGrade { get; set; }
 }

--- a/EcoScolarWebApi/Models/UserFavorite.cs
+++ b/EcoScolarWebApi/Models/UserFavorite.cs
@@ -19,5 +19,5 @@ public class UserFavorite
 	public long AdvertId { get; set; }
 
 	[ForeignKey("AdvertId")]
-	public virtual Advert? Advert { get; set; }
+	public virtual Advert? Advert { get; set; } = null!;
 }


### PR DESCRIPTION
## Summary
- Add match counting for search alerts based on advert type and saved criteria.
- Extend search alert DTOs with filter IDs and `matchedCount`.
- Show a red badge on the Alertes header item when alerts have matching adverts.
- Improve alert cards with explicit “articles found” status and “Voir les articles” CTA.