### PR TITLE
case sensitive fix for docker startup

### DIFF
--- a/EcoScolarWebApi/EcoScolarWebApi.slnx
+++ b/EcoScolarWebApi/EcoScolarWebApi.slnx
@@ -1,3 +1,3 @@
 <Solution>
-  <Project Path="EcoscolarWebApi.csproj" />
+  <Project Path="EcoScolarWebApi.csproj" />
 </Solution>


### PR DESCRIPTION
Le souci venait d'une incohérence de casse (majuscule/minuscule) dans le nom du fichier projet, ce qui pose problème lors de la construction Docker qui s'exécute généralement dans un environnement Linux sensible à la casse.

  Le fichier sur le disque était nommé EcoscolarWebApi.csproj (avec un s minuscule), alors que le Dockerfile, le fichier solution .slnx et les références de tests utilisaient EcoScolarWebApi.csproj (avec un S majuscule).

  J'ai effectué les corrections suivantes :
   1. Renommé EcoScolarWebApi/EcoscolarWebApi.csproj en EcoScolarWebApi/EcoScolarWebApi.csproj.
   2. Mis à jour le fichier solution interne EcoScolarWebApi/EcoScolarWebApi.slnx pour refléter ce changement.