### PR TITLE
feat(transactions): implement 7 days auto confirmation with Stripe transfer

### DIFF
--- a/EcoScolarWebApi/Controllers/MeController.cs
+++ b/EcoScolarWebApi/Controllers/MeController.cs
@@ -131,4 +131,33 @@ public class MeController : ControllerBase
         }
         return null;
     }
+
+    [HttpPost("sales/{transactionId}/confirm-shipping")]
+    public async Task<IActionResult> ConfirmShipping(long transactionId)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized(new { message = "Invalid session." });
+
+        var transaction = await _context.Transactions
+            .Include(t => t.Advert)
+            .FirstOrDefaultAsync(t => t.TransactionId == transactionId);
+
+        if (transaction == null)
+            return NotFound();
+
+        if (transaction.Advert.SellerId != userId)
+            return Forbid();
+
+        if (transaction.Status != TransactionStatus.PAID_WAITING_SHIPPING)
+            return BadRequest(new { message = "La transaction n'est pas en attente d'expédition." });
+
+        transaction.Status = TransactionStatus.SHIPPED;
+        transaction.ShippedDate = DateTime.UtcNow;
+
+        await _context.SaveChangesAsync();
+
+        return Ok();
+    }
 }

--- a/EcoScolarWebApi/Controllers/TransactionsController.cs
+++ b/EcoScolarWebApi/Controllers/TransactionsController.cs
@@ -86,6 +86,7 @@ public class TransactionsController(EcoscolarDbContext context, UserManager<User
 
 		var transaction = await _context.Transactions
 			.Include(t => t.Advert)
+                .ThenInclude(a => a.Seller)
 			.FirstOrDefaultAsync(t => t.TransactionId == transactionId);
 
 		if (transaction is null)
@@ -98,6 +99,29 @@ public class TransactionsController(EcoscolarDbContext context, UserManager<User
 		if (transaction.Advert != null)
 		{
 			transaction.Advert.Status = AdvertStatus.SOLD;
+
+            // Trigger Stripe transfer if the seller has a connected account
+            if (!string.IsNullOrEmpty(transaction.Advert.Seller?.StripeAccountId))
+            {
+                try
+                {
+                    var transferOptions = new Stripe.TransferCreateOptions
+                    {
+                        Amount = (long)(transaction.Advert.Price * 100), // en centimes
+                        Currency = "chf",
+                        Destination = transaction.Advert.Seller.StripeAccountId,
+                        TransferGroup = "COMMANDE_ID_789", // Same as defined in checkout
+                    };
+
+                    var transferService = new Stripe.TransferService();
+                    await transferService.CreateAsync(transferOptions);
+                }
+                catch (Stripe.StripeException ex)
+                {
+                    // Log the exception or handle it, but allow the transaction to be completed
+                    Console.WriteLine($"Stripe transfer failed: {ex.Message}");
+                }
+            }
 		}
 
 		await _context.SaveChangesAsync();

--- a/EcoScolarWebApi/Migrations/20260611143445_AddShippedDateToTransaction.Designer.cs
+++ b/EcoScolarWebApi/Migrations/20260611143445_AddShippedDateToTransaction.Designer.cs
@@ -4,6 +4,7 @@ using EcoScolarWebApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EcoScolarWebApi.Migrations
 {
     [DbContext(typeof(EcoscolarDbContext))]
-    partial class EcoscolarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611143445_AddShippedDateToTransaction")]
+    partial class AddShippedDateToTransaction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EcoScolarWebApi/Migrations/20260611143445_AddShippedDateToTransaction.cs
+++ b/EcoScolarWebApi/Migrations/20260611143445_AddShippedDateToTransaction.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoScolarWebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShippedDateToTransaction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ShippedDate",
+                table: "Transactions",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShippedDate",
+                table: "Transactions");
+        }
+    }
+}

--- a/EcoScolarWebApi/Models/Transaction.cs
+++ b/EcoScolarWebApi/Models/Transaction.cs
@@ -21,6 +21,8 @@ public class Transaction
 
     public DateTime? ExpirationReservationTime { get; set; }
 
+    public DateTime? ShippedDate { get; set; }
+
     [Required]
     [Column(TypeName = "decimal(18,2)")]
     public decimal PlatformFee { get; set; }

--- a/EcoScolarWebApi/Program.cs
+++ b/EcoScolarWebApi/Program.cs
@@ -4,6 +4,7 @@ using EcoScolarWebApi.Models;
 using EcoScolarWebApi.Services;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
+using EcoScolarWebApi.Mappers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,6 +12,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddAuthAndIdentity();
 builder.Services.AddSwaggerAndVersioning();
+
+builder.Services.AddHostedService<EcoScolarWebApi.Services.AutoConfirmReceiptService>();
 builder.Services.AddEcoScolarServices(builder.Configuration);
 builder.Services.AddMappersServices(builder.Configuration);
 

--- a/EcoScolarWebApi/Services/AutoConfirmReceiptService.cs
+++ b/EcoScolarWebApi/Services/AutoConfirmReceiptService.cs
@@ -1,0 +1,100 @@
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.Enums;
+using Microsoft.EntityFrameworkCore;
+using Stripe;
+
+namespace EcoScolarWebApi.Services;
+
+public class AutoConfirmReceiptService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<AutoConfirmReceiptService> _logger;
+
+    public AutoConfirmReceiptService(IServiceProvider serviceProvider, IConfiguration configuration, ILogger<AutoConfirmReceiptService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("AutoConfirmReceiptService running.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessAutoConfirmationsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred executing AutoConfirmReceiptService.");
+            }
+
+            // Attendre 24 heures (ou une autre durée configurée) avant de relancer
+            await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
+        }
+    }
+
+    private async Task ProcessAutoConfirmationsAsync(CancellationToken stoppingToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<EcoscolarDbContext>();
+
+        // Récupérer le délai de configuration (par défaut 7)
+        int delayDays = _configuration.GetValue<int>("BusinessSettings:SellerAutoPayoutDays", 7);
+        var thresholdDate = DateTime.UtcNow.AddDays(-delayDays);
+
+        var transactionsToConfirm = await context.Transactions
+            .Include(t => t.Advert)
+                .ThenInclude(a => a.Seller)
+            .Where(t => t.Status == TransactionStatus.SHIPPED 
+                     && t.ShippedDate.HasValue 
+                     && t.ShippedDate.Value <= thresholdDate)
+            .ToListAsync(stoppingToken);
+
+        if (transactionsToConfirm.Count == 0)
+            return;
+
+        _logger.LogInformation($"Found {transactionsToConfirm.Count} transactions to auto-confirm.");
+
+        var transferService = new TransferService();
+
+        foreach (var transaction in transactionsToConfirm)
+        {
+            transaction.Status = TransactionStatus.COMPLETED;
+            
+            if (transaction.Advert != null)
+            {
+                transaction.Advert.Status = AdvertStatus.SOLD;
+
+                // Trigger Stripe transfer if the seller has a connected account
+                if (!string.IsNullOrEmpty(transaction.Advert.Seller?.StripeAccountId))
+                {
+                    try
+                    {
+                        var transferOptions = new TransferCreateOptions
+                        {
+                            Amount = (long)(transaction.Advert.Price * 100), // en centimes
+                            Currency = "chf",
+                            Destination = transaction.Advert.Seller.StripeAccountId,
+                            TransferGroup = "COMMANDE_ID_789", // Same as defined in checkout
+                        };
+
+                        await transferService.CreateAsync(transferOptions, cancellationToken: stoppingToken);
+                        _logger.LogInformation($"Successfully transferred {transaction.Advert.Price} CHF to seller {transaction.Advert.SellerId} for transaction {transaction.TransactionId}");
+                    }
+                    catch (StripeException ex)
+                    {
+                        _logger.LogError(ex, $"Stripe transfer failed for transaction {transaction.TransactionId}");
+                    }
+                }
+            }
+        }
+
+        await context.SaveChangesAsync(stoppingToken);
+        _logger.LogInformation("Auto-confirmation process completed successfully.");
+    }
+}

--- a/EcoScolarWebApi/appsettings.json
+++ b/EcoScolarWebApi/appsettings.json
@@ -8,5 +8,8 @@
   "AllowedHosts": "*",
   "Features": {
     "UseFakeAdvertSearch": false
+  },
+  "BusinessSettings": {
+    "SellerAutoPayoutDays": 7
   }
 }


### PR DESCRIPTION
## Description
Implémentation du système de confirmation automatique de réception d'un achat. Si l'acheteur ne confirme pas manuellement la bonne réception de son article après un certain délai (7 jours), le système le fait automatiquement pour libérer le paiement auprès du vendeur via Stripe.

## Changements principaux
- **Base de données** : Ajout de la propriété `ShippedDate` au modèle `Transaction` (et ajout de la migration Entity Framework associée).
- **Configuration** : Ajout de la variable de configuration `BusinessSettings:SellerAutoPayoutDays` dans `appsettings.json`.
- **API** : Implémentation du endpoint `POST /api/v1/me/sales/{id}/confirm-shipping` appelé par le frontend lorsque le vendeur marque l'article comme expédié (met à jour le statut et enregistre la date).
- **Paiements Stripe** : 
  - Ajout du transfert des fonds (`Stripe.TransferService`) vers le compte connecté du vendeur dans l'action manuelle `ConfirmReceipt`.
- **Background Service** : Création du service `AutoConfirmReceiptService` tournant en tâche de fond (toutes les 24h). Il détecte les transactions expédiées depuis plus de 7 jours et exécute automatiquement la libération des fonds et le changement de statut (`COMPLETED`).

## Vérifications effectuées
- [x] Migration EF Core générée avec succès
- [x] Build du projet sans erreur