### PR TITLE
chore: document local backend compose override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ ScaffoldingReadMe.txt
 
 # dotenv environment variables file
 .env
+docker-compose.override.yaml
+docker-compose.override.yml
 
 # Others
 ~$*

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,15 @@
+# Example local override for the EcoScolar Pi deployment.
+#
+# Usage on the "ecole" machine only:
+# 1. Copy this file to docker-compose.override.yml
+# 2. Run: docker compose up -d ecoscolar-api-database
+#
+# Do not use this override for the whole team: it exposes SQL Server on the
+# host so the Raspberry Pi can reach the database through Tailscale.
+services:
+  ecoscolar-api-database:
+    ports:
+      - "0.0.0.0:1433:1433"
+    networks:
+      - databases
+      - dmz


### PR DESCRIPTION
## Summary
- Add a sample `docker-compose.override.example.yml` for local backend database exposure when needed from the Raspberry Pi.
- Ignore real local Docker Compose override files so machine-specific settings are not committed.