### PR TITLE
test: use in-memory factory for password flow tests

### DIFF
--- a/EcoScolarWebApi.Tests/Integration/PasswordFlowIntegrationTests.cs
+++ b/EcoScolarWebApi.Tests/Integration/PasswordFlowIntegrationTests.cs
@@ -1,16 +1,15 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
 namespace EcoScolarWebApi.Tests.Integration;
 
-public class PasswordFlowIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
+public class PasswordFlowIntegrationTests : IClassFixture<AuthInMemoryWebApplicationFactory>
 {
     private readonly HttpClient _client;
 
-    public PasswordFlowIntegrationTests(WebApplicationFactory<Program> factory)
+    public PasswordFlowIntegrationTests(AuthInMemoryWebApplicationFactory factory)
     {
         _client = factory.CreateClient();
     }


### PR DESCRIPTION
## Summary
- Update password flow integration tests to use the existing `AuthInMemoryWebApplicationFactory`.
- Avoid Windows EventLog permission failures during test startup by running these tests in the configured `Testing` environment.