### PR TITLE
feat: advert expiration background service and renew endpoint

### DIFF
--- a/EcoScolarWebApi/Controllers/MeController.cs
+++ b/EcoScolarWebApi/Controllers/MeController.cs
@@ -195,4 +195,32 @@ public class MeController : ControllerBase
 
         return Ok();
     }
+
+    [HttpPost("sales/{advertId}/renew")]
+    public async Task<IActionResult> RenewAdvert(long advertId)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized(new { message = "Invalid session." });
+
+        var advert = await _context.Adverts.FirstOrDefaultAsync(a => a.AdvertId == advertId);
+
+        if (advert == null)
+            return NotFound();
+
+        if (advert.SellerId != userId)
+            return Forbid();
+
+        if (advert.Status == AdvertStatus.SOLD || advert.Status == AdvertStatus.BLOCKED)
+            return BadRequest(new { message = "Cette annonce ne peut pas être renouvelée." });
+
+        advert.CreatedAt = DateTime.UtcNow;
+        advert.NotificationDate = DateTime.UtcNow;
+        advert.Status = AdvertStatus.ACTIVE;
+
+        await _context.SaveChangesAsync();
+
+        return Ok();
+    }
 }

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertDto.cs
@@ -107,6 +107,6 @@ public record AdvertCreateDto(string Title, string Description, decimal Price, s
 		entity.Price = Price;
 		entity.Status = AdvertStatus.ACTIVE;
 		entity.SellerId = UserId;
-		entity.NotificationDate = DateTime.UtcNow.AddMonths(3);
+		entity.NotificationDate = DateTime.UtcNow;
 	}
 }

--- a/EcoScolarWebApi/Program.cs
+++ b/EcoScolarWebApi/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddAuthAndIdentity();
 builder.Services.AddSwaggerAndVersioning();
 
 builder.Services.AddHostedService<EcoScolarWebApi.Services.AutoConfirmReceiptService>();
+builder.Services.AddHostedService<EcoScolarWebApi.Services.AdvertExpirationService>();
 builder.Services.AddEcoScolarServices(builder.Configuration);
 builder.Services.AddMappersServices(builder.Configuration);
 

--- a/EcoScolarWebApi/Services/AdvertExpirationService.cs
+++ b/EcoScolarWebApi/Services/AdvertExpirationService.cs
@@ -1,0 +1,104 @@
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.Enums;
+using EcoScolarWebApi.Services.Contracts;
+using Microsoft.EntityFrameworkCore;
+
+namespace EcoScolarWebApi.Services;
+
+public class AdvertExpirationService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<AdvertExpirationService> _logger;
+
+    public AdvertExpirationService(IServiceProvider serviceProvider, IConfiguration configuration, ILogger<AdvertExpirationService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("AdvertExpirationService running.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessAdvertExpirationsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred executing AdvertExpirationService.");
+            }
+
+            // Attendre 24 heures (ou une autre durée configurée) avant de relancer
+            await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
+        }
+    }
+
+    private async Task ProcessAdvertExpirationsAsync(CancellationToken stoppingToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<EcoscolarDbContext>();
+        var emailSender = scope.ServiceProvider.GetRequiredService<IEmailSenderService>();
+
+        int expirationDays = _configuration.GetValue<int>("BusinessSettings:AdvertExpirationDays", 30);
+        int notificationDays = _configuration.GetValue<int>("BusinessSettings:AdvertNotificationDays", 7);
+        int notifyThresholdDays = expirationDays - notificationDays; // typically 23
+
+        var thresholdExpire = DateTime.UtcNow.AddDays(-expirationDays);
+        var thresholdNotify = DateTime.UtcNow.AddDays(-notifyThresholdDays);
+
+        // 1. Process expirations (>= 30 days)
+        var advertsToExpire = await context.Adverts
+            .Where(a => a.Status == AdvertStatus.ACTIVE && a.CreatedAt <= thresholdExpire)
+            .ToListAsync(stoppingToken);
+
+        if (advertsToExpire.Count > 0)
+        {
+            _logger.LogInformation($"Found {advertsToExpire.Count} adverts to expire.");
+            foreach (var advert in advertsToExpire)
+            {
+                advert.Status = AdvertStatus.EXPIRED;
+            }
+        }
+
+        // 2. Process notifications (>= 23 days and < 30 days)
+        // We only notify if NotificationDate hasn't been updated for this cycle
+        // Using a safe margin, if NotificationDate < CreatedAt + 23 days, it means we haven't sent the warning
+        var advertsToNotify = await context.Adverts
+            .Include(a => a.Seller)
+            .Where(a => a.Status == AdvertStatus.ACTIVE 
+                     && a.CreatedAt <= thresholdNotify 
+                     && a.CreatedAt > thresholdExpire
+                     && a.NotificationDate < a.CreatedAt.AddDays(notifyThresholdDays))
+            .ToListAsync(stoppingToken);
+
+        if (advertsToNotify.Count > 0)
+        {
+            _logger.LogInformation($"Found {advertsToNotify.Count} adverts to notify for expiration warning.");
+            
+            var baseUrl = _configuration["Frontend:BaseUrl"] ?? "http://localhost:3000";
+
+            foreach (var advert in advertsToNotify)
+            {
+                if (advert.Seller?.Email != null)
+                {
+                    var renewLink = $"{baseUrl.TrimEnd('/')}/me/sales?renew={advert.AdvertId}";
+                    await emailSender.SendAdvertExpirationWarningAsync(advert.Seller, advert, renewLink);
+                }
+                
+                advert.NotificationDate = DateTime.UtcNow;
+            }
+        }
+
+        if (advertsToExpire.Count > 0 || advertsToNotify.Count > 0)
+        {
+            await context.SaveChangesAsync(stoppingToken);
+        }
+
+        _logger.LogInformation("Advert expiration process completed successfully.");
+    }
+}

--- a/EcoScolarWebApi/Services/Contracts/IEmailSenderService.cs
+++ b/EcoScolarWebApi/Services/Contracts/IEmailSenderService.cs
@@ -6,4 +6,5 @@ namespace EcoScolarWebApi.Services.Contracts;
 public interface IEmailSenderService : IEmailSender<User>
 {
     Task SendItemSoldEmailAsync(User seller, Advert advert);
+    Task SendAdvertExpirationWarningAsync(User seller, Advert advert, string renewLink);
 }

--- a/EcoScolarWebApi/Services/EmailSenderService.cs
+++ b/EcoScolarWebApi/Services/EmailSenderService.cs
@@ -81,6 +81,31 @@ public class EmailSenderService : IEmailSenderService
         await SendEmailAsync(seller.Email!, subject, body);
     }
 
+    public async Task SendAdvertExpirationWarningAsync(User seller, Advert advert, string renewLink)
+    {
+        var subject = "Votre annonce expire bientôt - EcoScolar";
+        var body = $"""
+        <div style="font-family: sans-serif; line-height: 1.5; color: #333;">
+            <p>Bonjour {seller.Nickname ?? seller.UserName ?? ""},</p>
+            <p>Votre annonce "<strong>{advert.Title}</strong>" expire dans 7 jours.</p>
+            <p>Sans action de votre part, elle sera retirée de la plateforme.</p>
+            <p style="margin: 24px 0;">
+                <a href="{renewLink}" 
+                   style="background-color: #28a745; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
+                   Renouveler mon annonce
+                </a>
+            </p>
+            <p style="font-size: 12px; color: #666;">
+                Si le bouton ne fonctionne pas, vous pouvez copier-coller ce lien dans votre navigateur :<br/>
+                <a href="{renewLink}">{renewLink}</a>
+            </p>
+            <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
+        </div>
+        """;
+
+        await SendEmailAsync(seller.Email!, subject, body);
+    }
+
     private async Task SendEmailAsync(string toEmail, string subject, string htmlMessage)
     {
         // Récupération de la config (ou valeurs par défaut pour le dev local)


### PR DESCRIPTION
## Description
Cette PR introduit le système de gestion d'expiration des annonces (cycle de 30 jours) avec notifications proactives par e-mail et possibilité de renouvellement.

## Changements principaux
- **Background Worker (`AdvertExpirationService`)** : 
  - Tourne en tâche de fond pour balayer les annonces actives.
  - Si une annonce a **plus de 23 jours**, envoie un e-mail d'avertissement au vendeur (avec un lien de renouvellement) et met à jour `NotificationDate` pour éviter les doublons.
  - Si une annonce a **30 jours ou plus**, bascule automatiquement son statut de `ACTIVE` à `EXPIRED`.
- **E-mails (`EmailSenderService`)** : Ajout de la méthode `SendAdvertExpirationWarningAsync` qui construit l'e-mail de rappel avec un lien pointant vers l'URL du frontend définie dans `appsettings.json`.
- **Endpoint API de renouvellement (`MeController`)** : 
  - Ajout de `POST /api/v1/me/sales/{id}/renew`.
  - Permet de renouveler une annonce en réinitialisant ses dates `CreatedAt` et `NotificationDate` à la date actuelle et en repassant son statut en `ACTIVE`.
- **Correction DTO** : `NotificationDate` s'initialise désormais par défaut à `DateTime.UtcNow` lors de la création d'une annonce, ce qui rend la donnée cohérente pour le background worker.

## Comment tester
1. Démarrer l'API et Mailpit.
2. Créer une annonce de test. En base de données, modifier son `CreatedAt` à `J-24`.
3. Attendre l'exécution du service de fond : un e-mail de rappel devrait arriver dans Mailpit.
4. Appeler le endpoint de `/renew` sur cette annonce et vérifier qu'elle repart pour un cycle de 30 jours (`CreatedAt` mis à jour).