### PR TITLE
Feature/catalog server pagination

### DIFF
--- a/EcoScolarWebApi.Tests/AdvertTest.cs
+++ b/EcoScolarWebApi.Tests/AdvertTest.cs
@@ -1321,17 +1321,24 @@ public class AdvertsControllerTests : IDisposable
     {
         // Arrange
         var query = new AdvertSearchQuery { Q = "Math" };
-        var expectedSummaries = new List<AdvertSummaryDto> { new AdvertSummaryDto { Id = 1 } };
+        var expectedPage = new CatalogSummaryPageDto
+        {
+            Items = new List<AdvertSummaryDto> { new AdvertSummaryDto { Id = 1 } },
+            Page = 1,
+            PageSize = 9,
+            TotalItems = 1,
+            TotalPages = 1
+        };
 
         _searchService.SearchSummariesAsync(query, Arg.Any<CancellationToken>())
-            .Returns(expectedSummaries);
+            .Returns(expectedPage);
 
         // Act
         var result = await _controller.GetSummaries(query, CancellationToken.None);
 
         // Assert
         var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
-        okResult.Value.Should().BeEquivalentTo(expectedSummaries);
+        okResult.Value.Should().BeEquivalentTo(expectedPage);
     }
     #endregion
 

--- a/EcoScolarWebApi.Tests/Integration/AdvertSearchServiceIntegrationTests.cs
+++ b/EcoScolarWebApi.Tests/Integration/AdvertSearchServiceIntegrationTests.cs
@@ -111,6 +111,27 @@ public class AdvertSearchServiceIntegrationTests : IDisposable
 		page.TotalItems.Should().Be(1);
 	}
 
+	[Fact]
+	public async Task SearchSummaries_ByReferenceIds_ReturnsMatchingAdverts()
+	{
+		await SeedCatalogAsync();
+
+		var booksPage = await _service.SearchSummariesAsync(new AdvertSearchQuery
+		{
+			BookCategoryIds = "1"
+		});
+		var tutoringPage = await _service.SearchSummariesAsync(new AdvertSearchQuery
+		{
+			SchoolGradeIds = "2",
+			SubjectIds = "4"
+		});
+
+		booksPage.Items.Should().ContainSingle();
+		booksPage.Items[0].Title.Should().Be("Manuel de Biologie");
+		tutoringPage.Items.Should().ContainSingle();
+		tutoringPage.Items[0].Title.Should().Be("Cours de mathématiques");
+	}
+
 	private async Task SeedCatalogAsync()
 	{
 		var user = new User

--- a/EcoScolarWebApi.Tests/Integration/AdvertSearchServiceIntegrationTests.cs
+++ b/EcoScolarWebApi.Tests/Integration/AdvertSearchServiceIntegrationTests.cs
@@ -39,7 +39,7 @@ public class AdvertSearchServiceIntegrationTests : IDisposable
 	{
 		await SeedCatalogAsync();
 
-		var results = (await _service.SearchSummariesAsync(new AdvertSearchQuery { Q = "Biologie" })).ToList();
+		var results = (await _service.SearchSummariesAsync(new AdvertSearchQuery { Q = "Biologie" })).Items.ToList();
 
 		results.Should().HaveCount(1);
 		results[0].Title.Should().Be("Manuel de Biologie");
@@ -51,7 +51,7 @@ public class AdvertSearchServiceIntegrationTests : IDisposable
 	{
 		await SeedCatalogAsync();
 
-		var results = (await _service.SearchSummariesAsync(new AdvertSearchQuery { Isbn = "978-3-16-148410-0" })).ToList();
+		var results = (await _service.SearchSummariesAsync(new AdvertSearchQuery { Isbn = "978-3-16-148410-0" })).Items.ToList();
 
 		results.Should().HaveCount(1);
 		results[0].Title.Should().Be("Manuel de Biologie");
@@ -63,7 +63,7 @@ public class AdvertSearchServiceIntegrationTests : IDisposable
 	{
 		await SeedCatalogAsync();
 
-		var results = (await _service.SearchSummariesAsync(new AdvertSearchQuery { Q = "Calculatrice" })).ToList();
+		var results = (await _service.SearchSummariesAsync(new AdvertSearchQuery { Q = "Calculatrice" })).Items.ToList();
 
 		results.Should().HaveCount(1);
 		results[0].Type.Should().Be(CatalogAdvertTypeCodes.Product);
@@ -75,9 +75,40 @@ public class AdvertSearchServiceIntegrationTests : IDisposable
 	{
 		await SeedCatalogAsync();
 
-		var results = (await _service.SearchSummariesAsync(null)).ToList();
+		var results = (await _service.SearchSummariesAsync(null)).Items.ToList();
 
 		results.Should().HaveCount(3);
+	}
+
+	[Fact]
+	public async Task SearchSummaries_WithPagination_ReturnsRequestedPageMetadata()
+	{
+		await SeedCatalogAsync();
+
+		var page = await _service.SearchSummariesAsync(new AdvertSearchQuery { Page = 2, PageSize = 2 });
+
+		page.Items.Should().HaveCount(1);
+		page.Page.Should().Be(2);
+		page.PageSize.Should().Be(2);
+		page.TotalItems.Should().Be(3);
+		page.TotalPages.Should().Be(2);
+	}
+
+	[Fact]
+	public async Task SearchSummaries_ByTypeAndSort_ReturnsOnlyMatchingAdverts()
+	{
+		await SeedCatalogAsync();
+
+		var page = await _service.SearchSummariesAsync(new AdvertSearchQuery
+		{
+			Type = CatalogAdvertTypeCodes.Service,
+			Sort = "price_desc"
+		});
+
+		page.Items.Should().ContainSingle();
+		page.Items[0].Type.Should().Be(CatalogAdvertTypeCodes.Service);
+		page.Items[0].Title.Should().Be("Cours de mathématiques");
+		page.TotalItems.Should().Be(1);
 	}
 
 	private async Task SeedCatalogAsync()

--- a/EcoScolarWebApi/Controllers/AdvertsController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertsController.cs
@@ -338,7 +338,7 @@ public class AdvertsController : ControllerBase
 	}
 
 	/// <summary>
-	/// Mock catalogue summaries (T5-1: Books-only filters <c>isbn</c> / <c>q</c>). GET api/v1/adverts/summary
+	/// Catalogue summaries paginés et filtrés. GET api/v1/adverts/summary
 	/// </summary>
 	[HttpGet("summary")]
 	public async Task<IActionResult> GetSummaries(

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertSearchQuery.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertSearchQuery.cs
@@ -4,18 +4,21 @@ namespace EcoScolarWebApi.DTOs.Adverts;
 /// Query parameters for PhysicalItem search (summary list).
 /// </summary>
 /// <remarks>
-/// For <c>GET api/v1/adverts/summary</c>, only <see cref="Q"/> and <see cref="Isbn"/> are honored by
-/// <see cref="Services.AdvertSearchService"/> and <see cref="Services.FakeAdvertSearchService"/>.
-/// <see cref="Category"/>, <see cref="MinPrice"/>, <see cref="MaxPrice"/>, <see cref="Subjects"/>, and
-/// <see cref="Grade"/> are reserved for future filtering and are currently ignored by the server.
+/// For <c>GET api/v1/adverts/summary</c>, filters are applied before pagination.
+/// <see cref="Category"/>, <see cref="Subjects"/>, and <see cref="Grade"/> accept one or more
+/// comma-separated canonical names from the reference tables.
 /// </remarks>
 public class AdvertSearchQuery
 {
 	public string? Q { get; set; }
 	public string? Isbn { get; set; }
+	public string? Type { get; set; }
 	public string? Category { get; set; }
 	public decimal? MinPrice { get; set; } = null;
 	public decimal? MaxPrice { get; set; }
 	public string? Subjects { get; set; }
 	public string? Grade { get; set; }
+	public string? Sort { get; set; }
+	public int? Page { get; set; }
+	public int? PageSize { get; set; }
 }

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertSearchQuery.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertSearchQuery.cs
@@ -5,14 +5,17 @@ namespace EcoScolarWebApi.DTOs.Adverts;
 /// </summary>
 /// <remarks>
 /// For <c>GET api/v1/adverts/summary</c>, filters are applied before pagination.
-/// <see cref="Category"/>, <see cref="Subjects"/>, and <see cref="Grade"/> accept one or more
-/// comma-separated canonical names from the reference tables.
+/// Prefer the ID filters for reference data. <see cref="Category"/>, <see cref="Subjects"/>, and
+/// <see cref="Grade"/> remain supported as comma-separated canonical names.
 /// </remarks>
 public class AdvertSearchQuery
 {
 	public string? Q { get; set; }
 	public string? Isbn { get; set; }
 	public string? Type { get; set; }
+	public string? BookCategoryIds { get; set; }
+	public string? SchoolGradeIds { get; set; }
+	public string? SubjectIds { get; set; }
 	public string? Category { get; set; }
 	public decimal? MinPrice { get; set; } = null;
 	public decimal? MaxPrice { get; set; }

--- a/EcoScolarWebApi/DTOs/Adverts/CatalogSummaryPageDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/CatalogSummaryPageDto.cs
@@ -1,0 +1,10 @@
+namespace EcoScolarWebApi.DTOs.Adverts;
+
+public record CatalogSummaryPageDto
+{
+	public IReadOnlyList<AdvertSummaryDto> Items { get; init; } = [];
+	public int Page { get; init; }
+	public int PageSize { get; init; }
+	public int TotalItems { get; init; }
+	public int TotalPages { get; init; }
+}

--- a/EcoScolarWebApi/Services/AdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/AdvertSearchService.cs
@@ -152,6 +152,15 @@ public sealed class AdvertSearchService : IAdvertSearchService
 		if (query.MaxPrice.HasValue)
 			advertsQuery = advertsQuery.Where(a => a.Price <= query.MaxPrice.Value);
 
+		var bookCategoryIds = SplitLongIds(query.BookCategoryIds);
+		if (bookCategoryIds.Length > 0)
+		{
+			advertsQuery = advertsQuery.Where(a =>
+				_context.Set<Book>().Any(b =>
+					b.AdvertId == a.AdvertId
+					&& bookCategoryIds.Contains(b.BookCategoryId)));
+		}
+
 		var categories = SplitTerms(query.Category);
 		if (categories.Length > 0)
 		{
@@ -162,6 +171,15 @@ public sealed class AdvertSearchService : IAdvertSearchService
 					&& categories.Contains(b.BookCategory.Name.ToLower())));
 		}
 
+		var schoolGradeIds = SplitLongIds(query.SchoolGradeIds);
+		if (schoolGradeIds.Length > 0)
+		{
+			advertsQuery = advertsQuery.Where(a =>
+				_context.Set<TutoringAdvert>().Any(s =>
+					s.AdvertId == a.AdvertId
+					&& schoolGradeIds.Contains(s.SchoolGradeId)));
+		}
+
 		var grades = SplitTerms(query.Grade);
 		if (grades.Length > 0)
 		{
@@ -170,6 +188,15 @@ public sealed class AdvertSearchService : IAdvertSearchService
 					s.AdvertId == a.AdvertId
 					&& s.SchoolGrade != null
 					&& grades.Contains(s.SchoolGrade.Name.ToLower())));
+		}
+
+		var subjectIds = SplitLongIds(query.SubjectIds);
+		if (subjectIds.Length > 0)
+		{
+			advertsQuery = advertsQuery.Where(a =>
+				_context.Set<TutoringAdvert>().Any(s =>
+					s.AdvertId == a.AdvertId
+					&& subjectIds.Contains(s.SubjectId)));
 		}
 
 		var subjects = SplitTerms(query.Subjects);
@@ -230,6 +257,17 @@ public sealed class AdvertSearchService : IAdvertSearchService
 			.Split(',', StringSplitOptions.RemoveEmptyEntries)
 			.Select(term => term.Trim().ToLowerInvariant())
 			.Where(term => term.Length > 0)
+			.Distinct()
+			.ToArray() ?? [];
+	}
+
+	private static long[] SplitLongIds(string? rawIds)
+	{
+		return rawIds?
+			.Split(',', StringSplitOptions.RemoveEmptyEntries)
+			.Select(id => long.TryParse(id.Trim(), out var parsed) ? parsed : (long?)null)
+			.Where(id => id.HasValue)
+			.Select(id => id!.Value)
 			.Distinct()
 			.ToArray() ?? [];
 	}

--- a/EcoScolarWebApi/Services/AdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/AdvertSearchService.cs
@@ -11,9 +11,14 @@ namespace EcoScolarWebApi.Services;
 /// Catalogue summaries/detail sur <see cref="Advert"/> (livres, produits hors livre, services).
 /// Filtre <c>isbn</c> : lignes résolues comme annonces reliées à <see cref="Book"/>.
 /// Filtre <c>q</c> : titre ou ISBN (pour les lignes livre uniquement dans la sous-requête).
+/// Les autres filtres et la pagination sont appliqués avant le mapping DTO.
 /// </summary>
 public sealed class AdvertSearchService : IAdvertSearchService
 {
+	private const int DefaultPage = 1;
+	private const int DefaultPageSize = 9;
+	private const int MaxPageSize = 50;
+
 	private readonly EcoscolarDbContext _context;
 
 	public AdvertSearchService(EcoscolarDbContext context)
@@ -21,7 +26,7 @@ public sealed class AdvertSearchService : IAdvertSearchService
 		_context = context;
 	}
 
-	public async Task<IEnumerable<AdvertSummaryDto>> SearchSummariesAsync(
+	public async Task<CatalogSummaryPageDto> SearchSummariesAsync(
 		AdvertSearchQuery? query,
 		CancellationToken cancellationToken = default)
 	{
@@ -29,34 +34,21 @@ public sealed class AdvertSearchService : IAdvertSearchService
 			.AsNoTracking()
 			.Where(a => a.Status == AdvertStatus.ACTIVE);
 
-		if (query != null && !string.IsNullOrWhiteSpace(query.Isbn))
+		if (query is not null)
 		{
-			var needle = Normalize(query.Isbn);
-
-			advertsQuery = advertsQuery.Where(a =>
-				_context.Set<Book>().Any(b =>
-					b.AdvertId == a.AdvertId
-					&& b.ISBN != null
-					&& b.ISBN.Trim() != string.Empty
-					&& b.ISBN.Replace("-", string.Empty).Trim().ToLower().Contains(needle)));
+			advertsQuery = ApplyFilters(advertsQuery, query);
 		}
 
-		if (query != null && !string.IsNullOrWhiteSpace(query.Q))
-		{
-			var keyword = query.Q.Trim();
-			var titleProbe = keyword.ToLower();
-			var isbnProbe = Normalize(keyword);
+		var pageSize = NormalizePageSize(query?.PageSize);
+		var page = NormalizePage(query?.Page);
+		var totalItems = await advertsQuery.CountAsync(cancellationToken);
+		var totalPages = Math.Max(1, (int)Math.Ceiling(totalItems / (double)pageSize));
+		page = Math.Min(page, totalPages);
 
-			advertsQuery = advertsQuery.Where(a =>
-				a.Title.ToLower().Contains(titleProbe)
-				|| _context.Set<Book>().Any(b =>
-					b.AdvertId == a.AdvertId
-					&& b.ISBN != null
-					&& b.ISBN.Trim() != string.Empty
-					&& b.ISBN.Replace("-", string.Empty).Trim().ToLower().Contains(isbnProbe)));
-		}
-
-		var adverts = await advertsQuery.ToListAsync(cancellationToken);
+		var adverts = await ApplySort(advertsQuery, query?.Sort)
+			.Skip((page - 1) * pageSize)
+			.Take(pageSize)
+			.ToListAsync(cancellationToken);
 
 		var bookAdvertIds = adverts.OfType<Book>().Select(b => b.AdvertId).Distinct().ToArray();
 		var serviceAdvertIds = adverts.OfType<TutoringAdvert>().Select(s => s.AdvertId).Distinct().ToArray();
@@ -77,7 +69,14 @@ public sealed class AdvertSearchService : IAdvertSearchService
 				.Where(s => serviceAdvertIds.Contains(s.AdvertId))
 				.ToDictionaryAsync(s => s.AdvertId, cancellationToken);
 
-		return adverts.Select(a => MapSummary(a, booksDict, servicesDict)).ToList();
+		return new CatalogSummaryPageDto
+		{
+			Items = adverts.Select(a => MapSummary(a, booksDict, servicesDict)).ToList(),
+			Page = page,
+			PageSize = pageSize,
+			TotalItems = totalItems,
+			TotalPages = totalPages
+		};
 	}
 
 	public async Task<AdvertDetailDto?> GetDetailAsync(long id, CancellationToken cancellationToken = default)
@@ -114,6 +113,125 @@ public sealed class AdvertSearchService : IAdvertSearchService
 			.FirstOrDefaultAsync(cancellationToken);
 
 		return productDetail == null ? null : ToDetailFromPhysical(productDetail);
+	}
+
+	private IQueryable<Advert> ApplyFilters(IQueryable<Advert> advertsQuery, AdvertSearchQuery query)
+	{
+		if (!string.IsNullOrWhiteSpace(query.Isbn))
+		{
+			var needle = Normalize(query.Isbn);
+
+			advertsQuery = advertsQuery.Where(a =>
+				_context.Set<Book>().Any(b =>
+					b.AdvertId == a.AdvertId
+					&& b.ISBN != null
+					&& b.ISBN.Trim() != string.Empty
+					&& b.ISBN.Replace("-", string.Empty).Trim().ToLower().Contains(needle)));
+		}
+
+		if (!string.IsNullOrWhiteSpace(query.Q))
+		{
+			var keyword = query.Q.Trim();
+			var titleProbe = keyword.ToLower();
+			var isbnProbe = Normalize(keyword);
+
+			advertsQuery = advertsQuery.Where(a =>
+				a.Title.ToLower().Contains(titleProbe)
+				|| _context.Set<Book>().Any(b =>
+					b.AdvertId == a.AdvertId
+					&& b.ISBN != null
+					&& b.ISBN.Trim() != string.Empty
+					&& b.ISBN.Replace("-", string.Empty).Trim().ToLower().Contains(isbnProbe)));
+		}
+
+		advertsQuery = ApplyTypeFilter(advertsQuery, query.Type);
+
+		if (query.MinPrice.HasValue)
+			advertsQuery = advertsQuery.Where(a => a.Price >= query.MinPrice.Value);
+
+		if (query.MaxPrice.HasValue)
+			advertsQuery = advertsQuery.Where(a => a.Price <= query.MaxPrice.Value);
+
+		var categories = SplitTerms(query.Category);
+		if (categories.Length > 0)
+		{
+			advertsQuery = advertsQuery.Where(a =>
+				_context.Set<Book>().Any(b =>
+					b.AdvertId == a.AdvertId
+					&& b.BookCategory != null
+					&& categories.Contains(b.BookCategory.Name.ToLower())));
+		}
+
+		var grades = SplitTerms(query.Grade);
+		if (grades.Length > 0)
+		{
+			advertsQuery = advertsQuery.Where(a =>
+				_context.Set<TutoringAdvert>().Any(s =>
+					s.AdvertId == a.AdvertId
+					&& s.SchoolGrade != null
+					&& grades.Contains(s.SchoolGrade.Name.ToLower())));
+		}
+
+		var subjects = SplitTerms(query.Subjects);
+		if (subjects.Length > 0)
+		{
+			advertsQuery = advertsQuery.Where(a =>
+				_context.Set<TutoringAdvert>().Any(s =>
+					s.AdvertId == a.AdvertId
+					&& s.Subject != null
+					&& subjects.Contains(s.Subject.Name.ToLower())));
+		}
+
+		return advertsQuery;
+	}
+
+	private static IQueryable<Advert> ApplyTypeFilter(IQueryable<Advert> advertsQuery, string? type)
+	{
+		return type?.Trim().ToUpperInvariant() switch
+		{
+			CatalogAdvertTypeCodes.Books => advertsQuery.Where(a => a is Book),
+			CatalogAdvertTypeCodes.Product => advertsQuery.Where(a => a is PhysicalItem && !(a is Book)),
+			CatalogAdvertTypeCodes.Service => advertsQuery.Where(a => a is TutoringAdvert),
+			_ => advertsQuery
+		};
+	}
+
+	private static IQueryable<Advert> ApplySort(IQueryable<Advert> advertsQuery, string? sort)
+	{
+		return sort?.Trim().ToLowerInvariant() switch
+		{
+			"price_asc" => advertsQuery
+				.OrderBy(a => a.Price)
+				.ThenByDescending(a => a.CreatedAt)
+				.ThenByDescending(a => a.AdvertId),
+			"price_desc" => advertsQuery
+				.OrderByDescending(a => a.Price)
+				.ThenByDescending(a => a.CreatedAt)
+				.ThenByDescending(a => a.AdvertId),
+			_ => advertsQuery
+				.OrderByDescending(a => a.CreatedAt)
+				.ThenByDescending(a => a.AdvertId)
+		};
+	}
+
+	private static int NormalizePage(int? page)
+	{
+		return Math.Max(DefaultPage, page ?? DefaultPage);
+	}
+
+	private static int NormalizePageSize(int? pageSize)
+	{
+		return Math.Clamp(pageSize ?? DefaultPageSize, 1, MaxPageSize);
+	}
+
+	private static string[] SplitTerms(string? rawTerms)
+	{
+		return rawTerms?
+			.Split(',', StringSplitOptions.RemoveEmptyEntries)
+			.Select(term => term.Trim().ToLowerInvariant())
+			.Where(term => term.Length > 0)
+			.Distinct()
+			.ToArray() ?? [];
 	}
 
 	private static AdvertSummaryDto MapSummary(

--- a/EcoScolarWebApi/Services/Contracts/IAdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/Contracts/IAdvertSearchService.cs
@@ -4,6 +4,6 @@ namespace EcoScolarWebApi.Services.Contracts;
 
 public interface IAdvertSearchService
 {
-    Task<IEnumerable<AdvertSummaryDto>> SearchSummariesAsync(AdvertSearchQuery? query, CancellationToken cancellationToken = default);
+    Task<CatalogSummaryPageDto> SearchSummariesAsync(AdvertSearchQuery? query, CancellationToken cancellationToken = default);
     Task<AdvertDetailDto?> GetDetailAsync(long id, CancellationToken cancellationToken = default);
 }

--- a/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/FakeAdvertSearchService.cs
@@ -11,6 +11,10 @@ namespace EcoScolarWebApi.Services;
 /// </summary>
 public class FakeAdvertSearchService : IAdvertSearchService
 {
+	private const int DefaultPage = 1;
+	private const int DefaultPageSize = 9;
+	private const int MaxPageSize = 50;
+
 	private sealed record CatalogMockEntry(AdvertSummaryDto Summary, string Description);
 
 	private static readonly IReadOnlyList<CatalogMockEntry> Catalog = BuildCatalog();
@@ -18,38 +22,37 @@ public class FakeAdvertSearchService : IAdvertSearchService
 	private static readonly IReadOnlyList<AdvertSummaryDto> Summaries =
 		Catalog.Select(e => e.Summary).ToList();
 
-	public Task<IEnumerable<AdvertSummaryDto>> SearchSummariesAsync(
+	public Task<CatalogSummaryPageDto> SearchSummariesAsync(
 		AdvertSearchQuery? query,
 		CancellationToken cancellationToken = default)
 	{
-		if (query == null)
-		{
-			return Task.FromResult<IEnumerable<AdvertSummaryDto>>(Summaries);
-		}
-
 		IEnumerable<AdvertSummaryDto> result = Summaries;
 
-		if (!string.IsNullOrWhiteSpace(query.Isbn))
+		if (query is not null)
 		{
-			var needle = Normalize(query.Isbn);
-			result = result.Where(a =>
-				a.Type == CatalogAdvertTypeCodes.Books
-				&& a.Isbn is not null
-				&& Normalize(a.Isbn).Contains(needle, StringComparison.Ordinal));
-        }
-
-		if (!string.IsNullOrWhiteSpace(query.Q))
-		{
-			var keyword = query.Q.Trim();
-			var normalizedIsbnProbe = Normalize(keyword);
-			result = result.Where(a =>
-				a.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase)
-				|| (a.Type == CatalogAdvertTypeCodes.Books
-					&& a.Isbn is not null
-					&& Normalize(a.Isbn).Contains(normalizedIsbnProbe, StringComparison.Ordinal)));
+			result = ApplyFilters(result, query);
 		}
 
-		return Task.FromResult<IEnumerable<AdvertSummaryDto>>(result.ToList());
+		var pageSize = NormalizePageSize(query?.PageSize);
+		var page = NormalizePage(query?.Page);
+		var sorted = ApplySort(result, query?.Sort).ToList();
+		var totalItems = sorted.Count;
+		var totalPages = Math.Max(1, (int)Math.Ceiling(totalItems / (double)pageSize));
+		page = Math.Min(page, totalPages);
+
+		var items = sorted
+			.Skip((page - 1) * pageSize)
+			.Take(pageSize)
+			.ToList();
+
+		return Task.FromResult(new CatalogSummaryPageDto
+		{
+			Items = items,
+			Page = page,
+			PageSize = pageSize,
+			TotalItems = totalItems,
+			TotalPages = totalPages
+		});
 	}
 
 	public Task<AdvertDetailDto?> GetDetailAsync(long id, CancellationToken cancellationToken = default)
@@ -157,6 +160,85 @@ public class FakeAdvertSearchService : IAdvertSearchService
 				Grade = "Lycée"
 			}, demoDesc)
 		};
+	}
+
+	private static IEnumerable<AdvertSummaryDto> ApplyFilters(IEnumerable<AdvertSummaryDto> result, AdvertSearchQuery query)
+	{
+		if (!string.IsNullOrWhiteSpace(query.Isbn))
+		{
+			var needle = Normalize(query.Isbn);
+			result = result.Where(a =>
+				a.Type == CatalogAdvertTypeCodes.Books
+				&& a.Isbn is not null
+				&& Normalize(a.Isbn).Contains(needle, StringComparison.Ordinal));
+		}
+
+		if (!string.IsNullOrWhiteSpace(query.Q))
+		{
+			var keyword = query.Q.Trim();
+			var normalizedIsbnProbe = Normalize(keyword);
+			result = result.Where(a =>
+				a.Title.Contains(keyword, StringComparison.OrdinalIgnoreCase)
+				|| (a.Type == CatalogAdvertTypeCodes.Books
+					&& a.Isbn is not null
+					&& Normalize(a.Isbn).Contains(normalizedIsbnProbe, StringComparison.Ordinal)));
+		}
+
+		if (!string.IsNullOrWhiteSpace(query.Type))
+		{
+			var type = query.Type.Trim();
+			result = result.Where(a => a.Type.Equals(type, StringComparison.OrdinalIgnoreCase));
+		}
+
+		if (query.MinPrice.HasValue)
+			result = result.Where(a => a.Price >= query.MinPrice.Value);
+
+		if (query.MaxPrice.HasValue)
+			result = result.Where(a => a.Price <= query.MaxPrice.Value);
+
+		var categories = SplitTerms(query.Category);
+		if (categories.Length > 0)
+			result = result.Where(a => a.Category is not null && categories.Contains(a.Category.Trim().ToLowerInvariant()));
+
+		var grades = SplitTerms(query.Grade);
+		if (grades.Length > 0)
+			result = result.Where(a => a.Grade is not null && grades.Contains(a.Grade.Trim().ToLowerInvariant()));
+
+		var subjects = SplitTerms(query.Subjects);
+		if (subjects.Length > 0)
+			result = result.Where(a => a.Subjects is not null && subjects.Contains(a.Subjects.Trim().ToLowerInvariant()));
+
+		return result;
+	}
+
+	private static IEnumerable<AdvertSummaryDto> ApplySort(IEnumerable<AdvertSummaryDto> result, string? sort)
+	{
+		return sort?.Trim().ToLowerInvariant() switch
+		{
+			"price_asc" => result.OrderBy(a => a.Price).ThenByDescending(a => a.Id),
+			"price_desc" => result.OrderByDescending(a => a.Price).ThenByDescending(a => a.Id),
+			_ => result.OrderByDescending(a => a.Id)
+		};
+	}
+
+	private static int NormalizePage(int? page)
+	{
+		return Math.Max(DefaultPage, page ?? DefaultPage);
+	}
+
+	private static int NormalizePageSize(int? pageSize)
+	{
+		return Math.Clamp(pageSize ?? DefaultPageSize, 1, MaxPageSize);
+	}
+
+	private static string[] SplitTerms(string? rawTerms)
+	{
+		return rawTerms?
+			.Split(',', StringSplitOptions.RemoveEmptyEntries)
+			.Select(term => term.Trim().ToLowerInvariant())
+			.Where(term => term.Length > 0)
+			.Distinct()
+			.ToArray() ?? [];
 	}
 
 	private static string Normalize(string? isbnText)


### PR DESCRIPTION
## Summary
- Add a paginated catalog summary response with `items`, `page`, `pageSize`, `totalItems`, and `totalPages`.
- Apply catalog search, type, reference ID filters, price filters, and sorting server-side before pagination.
- Update catalog search service tests to cover pagination metadata and reference ID filtering.
