### PR TITLE
Feature/abuse report

### DIFF
--- a/EcoScolarWebApi/Controllers/ReportsController.cs
+++ b/EcoScolarWebApi/Controllers/ReportsController.cs
@@ -1,0 +1,24 @@
+using EcoScolarWebApi.DTOs;
+using EcoScolarWebApi.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace EcoScolarWebApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ReportsController(IAbuseReportService reportService) : ControllerBase
+{
+    [HttpPost]
+    [Authorize]
+    public async Task<ActionResult<AbuseReportResponseDto>> CreateReport([FromBody] AbuseReportRequestDto requestDto)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized();
+
+        var response = await reportService.CreateReportAsync(requestDto, userId);
+        return CreatedAtAction(nameof(CreateReport), new { id = response.Id }, response);
+    }
+}

--- a/EcoScolarWebApi/DTOs/AbuseReportRequestDto.cs
+++ b/EcoScolarWebApi/DTOs/AbuseReportRequestDto.cs
@@ -1,0 +1,19 @@
+using EcoScolarWebApi.Enums;
+using System.ComponentModel.DataAnnotations;
+
+namespace EcoScolarWebApi.DTOs;
+
+public class AbuseReportRequestDto
+{
+    [Required]
+    public long TargetAdvertId { get; set; }
+
+    public int? TargetCommentId { get; set; }
+
+    [Required]
+    public ReportReason Reason { get; set; }
+
+    [Required]
+    [StringLength(2000, MinimumLength = 5)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/EcoScolarWebApi/DTOs/AbuseReportResponseDto.cs
+++ b/EcoScolarWebApi/DTOs/AbuseReportResponseDto.cs
@@ -1,0 +1,15 @@
+using EcoScolarWebApi.Enums;
+
+namespace EcoScolarWebApi.DTOs;
+
+public class AbuseReportResponseDto
+{
+    public int Id { get; set; }
+    public long TargetAdvertId { get; set; }
+    public int? TargetCommentId { get; set; }
+    public string ReporterUserId { get; set; } = string.Empty;
+    public ReportReason Reason { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public ReportStatus Status { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertDetailDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertDetailDto.cs
@@ -13,4 +13,5 @@ public record AdvertDetailDto
 	public string Description { get; set; } = string.Empty;
 	public string? ImageUrl { get; set; }
 	public string? sellerId { get; set; }
+	public int ExpiresInDays { get; set; }
 }

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertDto.cs
@@ -21,7 +21,8 @@ namespace EcoScolarWebApi.DTOs.Adverts;
 /// <param name="PrimaryImage">The URL of the primary image of the PhysicalItem</param>
 /// <param name="BuyerName">The nickname of the buyer once the advert has been sold. Empty string when the advert has not yet been sold.</param>
 /// <param name="Review">The review details of the advert/transaction if sold and reviewed.</param>
-public record AdvertReadDto(long Id, string Type, string Title, decimal Price, DateTime PublicationDate, DateTime NotificationDate, AdvertStatus Status, string UserId, string SellerPseudo, string? PrimaryImage, string BuyerName, ReviewDto? Review = null, long? TransactionId = null, string? TransactionStatus = null)
+/// <param name="ExpiresInDays">The number of days until the advert expires</param>
+public record AdvertReadDto(long Id, string Type, string Title, decimal Price, DateTime PublicationDate, DateTime NotificationDate, AdvertStatus Status, string UserId, string SellerPseudo, string? PrimaryImage, string BuyerName, int ExpiresInDays, ReviewDto? Review = null, long? TransactionId = null, string? TransactionStatus = null)
 {
 	/// <summary>
 	/// Factory method to create an AdvertReadDto from an PhysicalItem entity.
@@ -68,6 +69,7 @@ public record AdvertReadDto(long Id, string Type, string Title, decimal Price, D
 			SellerPseudo: entity.Seller?.Nickname ?? entity.Seller?.UserName ?? "Anonyme",
 			PrimaryImage: primaryImage,
 			BuyerName: buyerName ?? string.Empty,
+			ExpiresInDays: EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(entity.CreatedAt),
 			Review: review,
 			TransactionId: null,
 			TransactionStatus: null

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertSummaryDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertSummaryDto.cs
@@ -11,4 +11,5 @@ public record AdvertSummaryDto
 	public string? Subjects { get; set; }
 	public string? Grade { get; set; }
 	public string? sellerId { get; set; }
+	public int ExpiresInDays { get; set; }
 }

--- a/EcoScolarWebApi/DTOs/Adverts/BookDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/BookDto.cs
@@ -1,10 +1,10 @@
-﻿using EcoScolarWebApi.Enums;
+using EcoScolarWebApi.Enums;
 using EcoScolarWebApi.Models;
 
 namespace EcoScolarWebApi.DTOs.Adverts;
 
 public record BookReadDto(long id, string title, string description, decimal price, DateTime publicationDate, DateTime notificationDate, AdvertStatus status, string userId, string sellerPseudo,
-	List<string> pictures, PhysicalItemCondition condition, long bookCategoryId, string bookCategoryLabel, string isbn, string author, string publisher, string edition, Enums.LanguageEnum writtenLanguage, decimal? weight = null)
+	List<string> pictures, PhysicalItemCondition condition, long bookCategoryId, string bookCategoryLabel, string isbn, string author, string publisher, string edition, Enums.LanguageEnum writtenLanguage, int ExpiresInDays, decimal? weight = null)
 {
 	public static BookReadDto FromEntity(Book entity)
 	{
@@ -27,7 +27,8 @@ public record BookReadDto(long id, string title, string description, decimal pri
 			publisher: entity.Publisher,
 			edition: entity.Edition,
 			writtenLanguage: entity.WrittenLanguage,
-			pictures: entity.Pictures?.Select(p => p.Label).ToList() ?? new List<string>()
+			pictures: entity.Pictures?.Select(p => p.Label).ToList() ?? new List<string>(),
+			ExpiresInDays: EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(entity.CreatedAt)
 		);
 	}
 }

--- a/EcoScolarWebApi/DTOs/Adverts/ProductDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/ProductDto.cs
@@ -1,11 +1,11 @@
-﻿using EcoScolarWebApi.Enums;
+using EcoScolarWebApi.Enums;
 using EcoScolarWebApi.Models;
 using Microsoft.IdentityModel.Tokens;
 
 namespace EcoScolarWebApi.DTOs.Adverts;
 
 public record ProductReadDto(long Id, string Title, string Description, decimal Price, DateTime PublicationDate, DateTime NotificationDate, AdvertStatus Status, string UserId, string SellerPseudo,
-	List<string> Pictures, PhysicalItemCondition Condition, decimal? Weight, long? ProductCategoryId, string? ProductCategoryLabel)
+	List<string> Pictures, PhysicalItemCondition Condition, decimal? Weight, long? ProductCategoryId, string? ProductCategoryLabel, int ExpiresInDays)
 {
 	public static ProductReadDto FromEntity(PhysicalItem entity)
 	{
@@ -23,7 +23,8 @@ public record ProductReadDto(long Id, string Title, string Description, decimal 
 			Weight: entity.Weight ?? null,
 			ProductCategoryId: entity.ProductCategoryId ?? null,
 			ProductCategoryLabel: entity.ProductCategory?.Name ?? null,
-			Pictures: entity.Pictures?.Select(p => p.Label).ToList() ?? []
+			Pictures: entity.Pictures?.Select(p => p.Label).ToList() ?? [],
+			ExpiresInDays: EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(entity.CreatedAt)
 		);
 	}
 }

--- a/EcoScolarWebApi/DTOs/Adverts/ServiceDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/ServiceDto.cs
@@ -1,10 +1,10 @@
-﻿using EcoScolarWebApi.Enums;
+using EcoScolarWebApi.Enums;
 using EcoScolarWebApi.Models;
 
 namespace EcoScolarWebApi.DTOs.Adverts;
 
 public record ServiceReadDto(long Id, string Title, string Description, decimal Price, DateTime PublicationDate, DateTime NotificationDate, AdvertStatus Status, string UserId, string SellerPseudo,
-	long SubjectId, string SubjectLabel, long SchoolGradeId, string SchoolGradeLabel, Enums.LanguageEnum TeachingLanguage, string StudyLevel)
+	long SubjectId, string SubjectLabel, long SchoolGradeId, string SchoolGradeLabel, Enums.LanguageEnum TeachingLanguage, string StudyLevel, int ExpiresInDays)
 {
 	public static ServiceReadDto FromEntity(TutoringAdvert entity)
 	{
@@ -23,7 +23,8 @@ public record ServiceReadDto(long Id, string Title, string Description, decimal 
 			SchoolGradeId: entity.SchoolGradeId,
 			SchoolGradeLabel: entity.SchoolGrade.Name,
 			TeachingLanguage: entity.TeachingLanguage,
-			StudyLevel: entity.StudyLevel
+			StudyLevel: entity.StudyLevel,
+			ExpiresInDays: EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(entity.CreatedAt)
 		);
 	}
 }

--- a/EcoScolarWebApi/Data/EcoscolarDbContext.cs
+++ b/EcoScolarWebApi/Data/EcoscolarDbContext.cs
@@ -38,6 +38,7 @@ public class EcoscolarDbContext(DbContextOptions<EcoscolarDbContext> options) : 
 	public DbSet<SearchAlert> SearchAlerts { get; set; }
 	public DbSet<SupportTicket> SupportTickets { get; set; } = default!;
 	public DbSet<SupportTicketMessage> SupportTicketMessages { get; set; } = default!;
+	public DbSet<AbuseReport> AbuseReports { get; set; } = default!;
 
 	protected override void OnModelCreating(ModelBuilder builder)
 	{
@@ -172,6 +173,28 @@ public class EcoscolarDbContext(DbContextOptions<EcoscolarDbContext> options) : 
 				.WithMany()
 				.HasForeignKey(f => f.FlaggedId)
 				.OnDelete(DeleteBehavior.Cascade);
+		});
+
+		// AbuseReport
+		builder.Entity<AbuseReport>(entity =>
+		{
+			entity.Property(ar => ar.CreatedAt)
+				.HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+			entity.HasOne(ar => ar.Reporter)
+				.WithMany()
+				.HasForeignKey(ar => ar.ReporterUserId)
+				.OnDelete(DeleteBehavior.Restrict);
+
+			entity.HasOne(ar => ar.TargetAdvert)
+				.WithMany()
+				.HasForeignKey(ar => ar.TargetAdvertId)
+				.OnDelete(DeleteBehavior.Cascade);
+
+			entity.HasOne(ar => ar.TargetComment)
+				.WithMany()
+				.HasForeignKey(ar => ar.TargetCommentId)
+				.OnDelete(DeleteBehavior.NoAction);
 		});
 
 		// SearchAlert

--- a/EcoScolarWebApi/Enums/ReportReason.cs
+++ b/EcoScolarWebApi/Enums/ReportReason.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace EcoScolarWebApi.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ReportReason
+{
+    INAPPROPRIATE_ADVERT,
+    INAPPROPRIATE_COMMENT
+}

--- a/EcoScolarWebApi/Enums/ReportStatus.cs
+++ b/EcoScolarWebApi/Enums/ReportStatus.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace EcoScolarWebApi.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ReportStatus
+{
+    Pending,
+    Reviewed,
+    Resolved
+}

--- a/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
 		services.AddSingleton<UserMapper>();
         services.AddSingleton<ReviewMapper>();
         services.AddSingleton<LocationMapper>();
+        services.AddSingleton<AbuseReportMapper>();
         return services;
     }
 
@@ -126,6 +127,7 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<IAdminService, AdminService>();
 		services.AddScoped<ISupportContactService, SupportContactService>();
 		services.AddScoped<IStripeConnectService, StripeConnectService>();
+		services.AddScoped<IAbuseReportService, AbuseReportService>();
 
         return services;
 	}

--- a/EcoScolarWebApi/Helpers/AdvertExpirationHelper.cs
+++ b/EcoScolarWebApi/Helpers/AdvertExpirationHelper.cs
@@ -1,0 +1,15 @@
+using EcoScolarWebApi.Models;
+
+namespace EcoScolarWebApi.Helpers;
+
+public static class AdvertExpirationHelper
+{
+    public const int DefaultExpirationDays = 30;
+
+    public static int GetExpiresInDays(DateTime createdAt)
+    {
+        var expirationDate = createdAt.AddDays(DefaultExpirationDays);
+        var remaining = (int)(expirationDate - DateTime.UtcNow).TotalDays;
+        return remaining < 0 ? 0 : remaining;
+    }
+}

--- a/EcoScolarWebApi/Mappers/AbuseReportMapper.cs
+++ b/EcoScolarWebApi/Mappers/AbuseReportMapper.cs
@@ -7,6 +7,9 @@ namespace EcoScolarWebApi.Mappers;
 [Mapper]
 public partial class AbuseReportMapper
 {
+    [MapperIgnoreSource(nameof(AbuseReport.Reporter))]
+    [MapperIgnoreSource(nameof(AbuseReport.TargetComment))]
+    [MapperIgnoreSource(nameof(AbuseReport.TargetAdvert))]
     public partial AbuseReportResponseDto ToAbuseReportResponse(AbuseReport report);
 
     public partial IQueryable<AbuseReportResponseDto> ProjectToAbuseReportResponses(IQueryable<AbuseReport> query);

--- a/EcoScolarWebApi/Mappers/AbuseReportMapper.cs
+++ b/EcoScolarWebApi/Mappers/AbuseReportMapper.cs
@@ -1,0 +1,13 @@
+using EcoScolarWebApi.DTOs;
+using EcoScolarWebApi.Models;
+using Riok.Mapperly.Abstractions;
+
+namespace EcoScolarWebApi.Mappers;
+
+[Mapper]
+public partial class AbuseReportMapper
+{
+    public partial AbuseReportResponseDto ToAbuseReportResponse(AbuseReport report);
+
+    public partial IQueryable<AbuseReportResponseDto> ProjectToAbuseReportResponses(IQueryable<AbuseReport> query);
+}

--- a/EcoScolarWebApi/Migrations/20260614161539_AddAbuseReportsTable.Designer.cs
+++ b/EcoScolarWebApi/Migrations/20260614161539_AddAbuseReportsTable.Designer.cs
@@ -4,6 +4,7 @@ using EcoScolarWebApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EcoScolarWebApi.Migrations
 {
     [DbContext(typeof(EcoscolarDbContext))]
-    partial class EcoscolarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260614161539_AddAbuseReportsTable")]
+    partial class AddAbuseReportsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EcoScolarWebApi/Migrations/20260614161539_AddAbuseReportsTable.cs
+++ b/EcoScolarWebApi/Migrations/20260614161539_AddAbuseReportsTable.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoScolarWebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAbuseReportsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AbuseReports",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TargetAdvertId = table.Column<long>(type: "bigint", nullable: false),
+                    TargetCommentId = table.Column<int>(type: "int", nullable: true),
+                    ReporterUserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Reason = table.Column<int>(type: "int", nullable: false),
+                    Message = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AbuseReports", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AbuseReports_Adverts_TargetAdvertId",
+                        column: x => x.TargetAdvertId,
+                        principalTable: "Adverts",
+                        principalColumn: "AdvertId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AbuseReports_AspNetUsers_ReporterUserId",
+                        column: x => x.ReporterUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_AbuseReports_PublicComments_TargetCommentId",
+                        column: x => x.TargetCommentId,
+                        principalTable: "PublicComments",
+                        principalColumn: "CommentId");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AbuseReports_ReporterUserId",
+                table: "AbuseReports",
+                column: "ReporterUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AbuseReports_TargetAdvertId",
+                table: "AbuseReports",
+                column: "TargetAdvertId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AbuseReports_TargetCommentId",
+                table: "AbuseReports",
+                column: "TargetCommentId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AbuseReports");
+        }
+    }
+}

--- a/EcoScolarWebApi/Models/AbuseReport.cs
+++ b/EcoScolarWebApi/Models/AbuseReport.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using EcoScolarWebApi.Enums;
+
+namespace EcoScolarWebApi.Models;
+
+[Table("AbuseReports")]
+public class AbuseReport
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public long TargetAdvertId { get; set; }
+
+    public int? TargetCommentId { get; set; }
+
+    [Required]
+    public string ReporterUserId { get; set; } = string.Empty;
+
+    [Required]
+    public ReportReason Reason { get; set; }
+
+    [Required]
+    public string Message { get; set; } = string.Empty;
+
+    [Required]
+    public ReportStatus Status { get; set; } = ReportStatus.Pending;
+
+    [Required]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    // Navigation Properties
+    [ForeignKey(nameof(TargetAdvertId))]
+    public virtual Advert? TargetAdvert { get; set; }
+
+    [ForeignKey(nameof(TargetCommentId))]
+    public virtual PublicComment? TargetComment { get; set; }
+
+    [ForeignKey(nameof(ReporterUserId))]
+    public virtual User? Reporter { get; set; }
+}

--- a/EcoScolarWebApi/Services/AbuseReportService.cs
+++ b/EcoScolarWebApi/Services/AbuseReportService.cs
@@ -1,0 +1,30 @@
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.DTOs;
+using EcoScolarWebApi.Enums;
+using EcoScolarWebApi.Mappers;
+using EcoScolarWebApi.Models;
+
+namespace EcoScolarWebApi.Services;
+
+public class AbuseReportService(EcoscolarDbContext context) : IAbuseReportService
+{
+    public async Task<AbuseReportResponseDto> CreateReportAsync(AbuseReportRequestDto requestDto, string reporterUserId)
+    {
+        var report = new AbuseReport
+        {
+            TargetAdvertId = requestDto.TargetAdvertId,
+            TargetCommentId = requestDto.TargetCommentId,
+            Reason = requestDto.Reason,
+            Message = requestDto.Message,
+            ReporterUserId = reporterUserId,
+            Status = ReportStatus.Pending,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        context.AbuseReports.Add(report);
+        await context.SaveChangesAsync();
+
+        var mapper = new AbuseReportMapper();
+        return mapper.ToAbuseReportResponse(report);
+    }
+}

--- a/EcoScolarWebApi/Services/AdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/AdvertSearchService.cs
@@ -1,4 +1,4 @@
-﻿using EcoScolarWebApi.Data;
+using EcoScolarWebApi.Data;
 using EcoScolarWebApi.DTOs.Adverts;
 using EcoScolarWebApi.Models;
 using EcoScolarWebApi.Services.Contracts;
@@ -137,7 +137,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 						Category = src.BookCategory?.Name,
 						Subjects = null,
 						Grade = null,
-						sellerId = bk.SellerId
+						sellerId = bk.SellerId,
+						ExpiresInDays = EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(src.CreatedAt)
 					};
 				}
 			case TutoringAdvert svc:
@@ -154,7 +155,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 						Category = null,
 						Subjects = src.Subject?.Name,
 						Grade = src.SchoolGrade?.Name,
-						sellerId = svc.SellerId
+						sellerId = svc.SellerId,
+						ExpiresInDays = EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(src.CreatedAt)
 					};
 				}
 			case PhysicalItem phy when phy is not Book:
@@ -168,7 +170,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 					Category = null,
 					Subjects = null,
 					Grade = null,
-					sellerId = phy.SellerId
+					sellerId = phy.SellerId,
+					ExpiresInDays = EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(phy.CreatedAt)
 				};
 			default:
 				throw new InvalidOperationException($"Unknown PhysicalItem CLR type '{a.GetType().Name}'.");
@@ -191,7 +194,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 			Price = b.Price,
 			Description = b.Description ?? string.Empty,
 			ImageUrl = imageUrl,
-			sellerId = b.SellerId
+			sellerId = b.SellerId,
+			ExpiresInDays = EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(b.CreatedAt)
 		};
 	}
 
@@ -209,7 +213,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 			Price = s.Price,
 			Description = s.Description ?? string.Empty,
 			ImageUrl = null,
-			sellerId = s.SellerId
+			sellerId = s.SellerId,
+			ExpiresInDays = EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(s.CreatedAt)
 		};
 	}
 
@@ -228,7 +233,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 			Price = p.Price,
 			Description = p.Description ?? string.Empty,
 			ImageUrl = imageUrl,
-			sellerId = p.SellerId
+			sellerId = p.SellerId,
+			ExpiresInDays = EcoScolarWebApi.Helpers.AdvertExpirationHelper.GetExpiresInDays(p.CreatedAt)
 		};
 	}
 

--- a/EcoScolarWebApi/Services/IAbuseReportService.cs
+++ b/EcoScolarWebApi/Services/IAbuseReportService.cs
@@ -1,0 +1,8 @@
+using EcoScolarWebApi.DTOs;
+
+namespace EcoScolarWebApi.Services;
+
+public interface IAbuseReportService
+{
+    Task<AbuseReportResponseDto> CreateReportAsync(AbuseReportRequestDto requestDto, string reporterUserId);
+}


### PR DESCRIPTION
## Description
Cette PR introduit un système complet de signalement, permettant aux utilisateurs de remonter à l'administration des annonces ou des commentaires jugés inappropriés. Elle couvre à la fois l'infrastructure backend et l'interface utilisateur frontend.

## Changements apportés

### Backend (ecoscolar-web-api)
* **Base de données & Modèles :**
  * Création de l'entité `AbuseReport` rattachée à l'auteur du signalement, à l'annonce ciblée et potentiellement au commentaire ciblé.
  * Ajout de l'énumération `ReportReason` (`InappropriateAdvert`, `InappropriateComment`).
  * Ajout de l'énumération `ReportStatus` (`Pending`, `Reviewed`, `Resolved`).
  * Création et application de la migration Entity Framework correspondante.
* **Services & API :**
  * Ajout de `AbuseReportRequestDto` et `AbuseReportResponseDto`.
  * Implémentation du `AbuseReportService` pour gérer la logique d'enregistrement des signalements.
  * Création du `ReportsController` exposant le point d'entrée `POST /api/reports`.
* **Refactor :**
  * Ajout de `ExpiresInDays` sur tous les DTOs d'annonce pour centraliser la logique de calcul d'expiration sur le backend.

### Frontend (ecoscolar-web-ui)
* **Composants :**
  * Création du composant réutilisable `ReportAbuseModal.vue` pour gérer le formulaire de signalement.
  * Intégration d'un bouton de signalement sur la page de détail d'une annonce (`adverts/[id].vue`), avec le motif "Annonce inappropriée" par défaut.
  * Intégration d'un bouton de signalement à côté des questions/commentaires publics (`PublicQuestions.vue`), avec le motif "Commentaire inapproprié" par défaut.
* **Logique Client :**
  * Création du composable `useAbuseReport.ts` pour gérer les appels API et l'état de la fenêtre modale.

## Vérifications
- [x] Vérifié que l'enregistrement d'un signalement sauvegarde correctement l'entrée en base de données avec les bonnes clés étrangères.
- [x] Vérifié que les nouveaux signalements ont le statut `Pending` par défaut.
- [x] Vérifié que la modale s'ouvre/ferme correctement et déclenche le bon appel API côté front.
- [x] Vérifié que le backend calcule correctement et renvoie le `ExpiresInDays` dans les DTOs d'annonce.