### PR TITLE
feat: ajout routes pour litige

### DIFF
--- a/EcoScolarWebApi.Tests/Unit/Controllers/AdminsControllerTests.cs
+++ b/EcoScolarWebApi.Tests/Unit/Controllers/AdminsControllerTests.cs
@@ -141,7 +141,7 @@ public class AdminsControllerTests : IDisposable
     {
         // Arrange
         var advertId = 100L;
-        var response = new AdvertReadDto(advertId, "BOOK", "Blocked", 10m, DateTime.UtcNow, DateTime.UtcNow, AdvertStatus.BLOCKED, "seller-1", "Seller", null, "");
+        var response = new AdvertReadDto(advertId, "BOOK", "Blocked", 10m, DateTime.UtcNow, DateTime.UtcNow, AdvertStatus.BLOCKED, "seller-1", "Seller", null, "", 30);
         _adminServiceMock.BlockAdvert(Arg.Any<ClaimsPrincipal>(), advertId)
             .Returns(Result<AdvertReadDto>.Success(response));
 

--- a/EcoScolarWebApi/Controllers/TransactionsController.cs
+++ b/EcoScolarWebApi/Controllers/TransactionsController.cs
@@ -146,11 +146,15 @@ public class TransactionsController(EcoscolarDbContext context, UserManager<User
 		if (transaction.BuyerId != user.Id)
 			return Forbid();
 
+		if (transaction.Status != TransactionStatus.SHIPPED)
+			return BadRequest(new { message = "You can only dispute a shipped order." });
+
 		var dispute = new Dispute
 		{
 			TransactionId = transactionId,
 			Reason = request.Reason,
-			Status = "OPEN",
+			Description = request.Description,
+			Status = EcoScolarWebApi.Enums.TicketStatus.Pending,
 			Date = DateTime.UtcNow
 		};
 

--- a/EcoScolarWebApi/DTOs/AbuseReportResponseDto.cs
+++ b/EcoScolarWebApi/DTOs/AbuseReportResponseDto.cs
@@ -10,6 +10,6 @@ public class AbuseReportResponseDto
     public string ReporterUserId { get; set; } = string.Empty;
     public ReportReason Reason { get; set; }
     public string Message { get; set; } = string.Empty;
-    public ReportStatus Status { get; set; }
+    public TicketStatus Status { get; set; }
     public DateTime CreatedAt { get; set; }
 }

--- a/EcoScolarWebApi/DTOs/Transactions/DisputeRequestDto.cs
+++ b/EcoScolarWebApi/DTOs/Transactions/DisputeRequestDto.cs
@@ -5,5 +5,8 @@ namespace EcoScolarWebApi.DTOs.Transactions;
 public record DisputeRequestDto
 {
     [Required]
-    public string Reason { get; init; } = string.Empty;
+    public EcoScolarWebApi.Enums.DisputeReason Reason { get; init; }
+
+    [Required]
+    public string Description { get; init; } = string.Empty;
 }

--- a/EcoScolarWebApi/Enums/DisputeReason.cs
+++ b/EcoScolarWebApi/Enums/DisputeReason.cs
@@ -3,9 +3,9 @@ using System.Text.Json.Serialization;
 namespace EcoScolarWebApi.Enums;
 
 [JsonConverter(typeof(JsonStringEnumConverter))]
-public enum ReportStatus
+public enum DisputeReason
 {
-    Pending,
-    Reviewed,
-    Resolved
+    ItemNotReceived,
+    NotAsDescribed,
+    Damaged
 }

--- a/EcoScolarWebApi/Enums/TicketStatus.cs
+++ b/EcoScolarWebApi/Enums/TicketStatus.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace EcoScolarWebApi.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TicketStatus
+{
+    Pending,
+    Reviewed,
+    Resolved
+}

--- a/EcoScolarWebApi/Migrations/20260614174332_UpdateDisputeWithEnums.Designer.cs
+++ b/EcoScolarWebApi/Migrations/20260614174332_UpdateDisputeWithEnums.Designer.cs
@@ -4,6 +4,7 @@ using EcoScolarWebApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EcoScolarWebApi.Migrations
 {
     [DbContext(typeof(EcoscolarDbContext))]
-    partial class EcoscolarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260614174332_UpdateDisputeWithEnums")]
+    partial class UpdateDisputeWithEnums
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EcoScolarWebApi/Migrations/20260614174332_UpdateDisputeWithEnums.cs
+++ b/EcoScolarWebApi/Migrations/20260614174332_UpdateDisputeWithEnums.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoScolarWebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateDisputeWithEnums : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Status",
+                table: "Disputes",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Reason",
+                table: "Disputes",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Disputes",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Reason",
+                table: "Disputes",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+    }
+}

--- a/EcoScolarWebApi/Models/AbuseReport.cs
+++ b/EcoScolarWebApi/Models/AbuseReport.cs
@@ -25,7 +25,7 @@ public class AbuseReport
     public string Message { get; set; } = string.Empty;
 
     [Required]
-    public ReportStatus Status { get; set; } = ReportStatus.Pending;
+    public TicketStatus Status { get; set; } = TicketStatus.Pending;
 
     [Required]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/EcoScolarWebApi/Models/Dispute.cs
+++ b/EcoScolarWebApi/Models/Dispute.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace EcoScolarWebApi.Models;
@@ -13,7 +13,7 @@ public class Dispute
     public long TransactionId { get; set; }
 
     [Required]
-    public string Reason { get; set; } = string.Empty;
+    public EcoScolarWebApi.Enums.DisputeReason Reason { get; set; }
 
     public string? Description { get; set; }
 
@@ -21,7 +21,7 @@ public class Dispute
     public DateTime Date { get; set; } = DateTime.UtcNow;
 
     [Required]
-    public string Status { get; set; } = string.Empty;
+    public EcoScolarWebApi.Enums.TicketStatus Status { get; set; } = EcoScolarWebApi.Enums.TicketStatus.Pending;
 
     public string? Resolution { get; set; }
 

--- a/EcoScolarWebApi/Services/AbuseReportService.cs
+++ b/EcoScolarWebApi/Services/AbuseReportService.cs
@@ -17,7 +17,7 @@ public class AbuseReportService(EcoscolarDbContext context) : IAbuseReportServic
             Reason = requestDto.Reason,
             Message = requestDto.Message,
             ReporterUserId = reporterUserId,
-            Status = ReportStatus.Pending,
+            Status = TicketStatus.Pending,
             CreatedAt = DateTime.UtcNow
         };
 


### PR DESCRIPTION
## Description
Cette PR met en place les fondations backend du système de litige, permettant aux acheteurs de signaler un problème lié à une transaction expédiée. Elle harmonise également les statuts de traitement administratif.

## Changements apportés
* **Base de données & Modèles :**
  * Renommage de l'énumération `ReportStatus` en `TicketStatus` (`Pending`, `Reviewed`, `Resolved`) pour uniformiser la gestion de tous les tickets administratifs (Signalements et Litiges).
  * Création de l'énumération `DisputeReason` (`ItemNotReceived`, `NotAsDescribed`, `Damaged`) définissant les motifs précis de litige.
  * Mise à jour du modèle `Dispute` pour intégrer ces deux énumérations ainsi qu'un champ texte `Description`.
  * Création et application d'une migration Entity Framework.
* **Services & API :**
  * Mise à jour du `DisputeRequestDto` pour nécessiter `Reason` (Enum) et `Description` (string).
  * Dans `TransactionsController` (méthode `DisputePurchase`), ajout d'une vérification stricte : le litige n'est accepté que si la transaction est au statut `SHIPPED`.

## Vérifications
- [x] Vérifié que la migration de la base de données s'applique correctement et sans perte d'intégrité.
- [x] Vérifié qu'un litige ne peut être ouvert que sur une transaction `SHIPPED`.
- [x] Vérifié que l'ouverture du litige passe la transaction en statut `DISPUTED`, empêchant techniquement la confirmation de réception et conservant de facto l'argent de la commande sur le solde de la plateforme.