### PR TITLE
Feature/minio image storage

### DIFF
--- a/EcoScolarWebApi/Controllers/AdvertPicturesController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertPicturesController.cs
@@ -63,6 +63,11 @@ public class AdvertPicturesController : ControllerBase
             return BadRequest(new { error = $"Maximum {MaxPicturesPerAdvert} images par annonce (actuellement {existingCount})." });
 
         var created = new List<PictureDto>();
+        var uploadedKeys = new List<string>();
+
+        var nextOrder = advert.Pictures.Count > 0
+            ? advert.Pictures.Max(p => p.SortOrder) + 1
+            : 0;
 
         foreach (var file in files)
         {
@@ -70,15 +75,12 @@ public class AdvertPicturesController : ControllerBase
             try
             {
                 stored = await _imageStorage.UploadAsync(file, $"adverts/{advertId}", ct);
+                uploadedKeys.Add(stored.ObjectKey);
             }
             catch (InvalidOperationException ex)
             {
                 return BadRequest(new { error = ex.Message });
             }
-
-            var nextOrder = advert.Pictures.Count > 0
-                ? advert.Pictures.Max(p => p.SortOrder) + 1
-                : 0;
 
             var picture = new Picture
             {
@@ -86,15 +88,24 @@ public class AdvertPicturesController : ControllerBase
                 ObjectKey = stored.ObjectKey,
                 ContentType = stored.ContentType,
                 PublicUrl = stored.PublicUrl,
-                SortOrder = nextOrder,
+                SortOrder = nextOrder++,
                 PhysicalItemId = advertId
             };
 
             _context.Pictures.Add(picture);
-            await _context.SaveChangesAsync(ct);
-
             advert.Pictures.Add(picture);
             created.Add(new PictureDto(picture.PictureId, stored.PublicUrl, picture.SortOrder));
+        }
+
+        try
+        {
+            await _context.SaveChangesAsync(ct);
+        }
+        catch (Exception)
+        {
+            foreach (var key in uploadedKeys)
+                await _imageStorage.DeleteAsync(key, ct).ConfigureAwait(false);
+            throw;
         }
 
         return Ok(created);

--- a/EcoScolarWebApi/Controllers/AdvertPicturesController.cs
+++ b/EcoScolarWebApi/Controllers/AdvertPicturesController.cs
@@ -1,0 +1,141 @@
+using Asp.Versioning;
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.DTOs.Adverts;
+using EcoScolarWebApi.Models;
+using EcoScolarWebApi.Services.Contracts;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace EcoScolarWebApi.Controllers;
+
+/// <summary>
+/// Manages images (pictures) attached to adverts.
+/// POST  /api/v1/adverts/{advertId}/pictures       – upload up to 5 images
+/// DELETE /api/v1/adverts/{advertId}/pictures/{pictureId} – delete an image
+/// </summary>
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/adverts/{advertId:long}/pictures")]
+[ApiController]
+[Authorize]
+public class AdvertPicturesController : ControllerBase
+{
+    private const int MaxPicturesPerAdvert = 5;
+
+    private readonly EcoscolarDbContext _context;
+    private readonly IImageStorageService _imageStorage;
+
+    public AdvertPicturesController(EcoscolarDbContext context, IImageStorageService imageStorage)
+    {
+        _context = context;
+        _imageStorage = imageStorage;
+    }
+
+    /// <summary>
+    /// Upload one or more images for an advert (max 5 total including existing ones).
+    /// Only the advert owner or an admin can upload pictures.
+    /// </summary>
+    [HttpPost]
+    [Consumes("multipart/form-data")]
+    [RequestSizeLimit(25 * 1024 * 1024)] // 5 files × 5 MB
+    public async Task<ActionResult<IEnumerable<PictureDto>>> UploadPictures(
+        long advertId,
+        [FromForm] IFormFileCollection files,
+        CancellationToken ct = default)
+    {
+        if (files == null || files.Count == 0)
+            return BadRequest(new { error = "Aucun fichier reçu." });
+
+        var advert = await _context.Products
+            .Include(p => p.Pictures)
+            .FirstOrDefaultAsync(p => p.AdvertId == advertId, ct);
+
+        if (advert == null)
+            return NotFound(new { error = $"Annonce {advertId} introuvable." });
+
+        var currentUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (advert.SellerId != currentUserId && !User.IsInRole("Admin"))
+            return Forbid();
+
+        var existingCount = advert.Pictures.Count;
+        if (existingCount + files.Count > MaxPicturesPerAdvert)
+            return BadRequest(new { error = $"Maximum {MaxPicturesPerAdvert} images par annonce (actuellement {existingCount})." });
+
+        var created = new List<PictureDto>();
+
+        foreach (var file in files)
+        {
+            StoredImageResult stored;
+            try
+            {
+                stored = await _imageStorage.UploadAsync(file, $"adverts/{advertId}", ct);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { error = ex.Message });
+            }
+
+            var nextOrder = advert.Pictures.Count > 0
+                ? advert.Pictures.Max(p => p.SortOrder) + 1
+                : 0;
+
+            var picture = new Picture
+            {
+                Label = stored.ObjectKey,
+                ObjectKey = stored.ObjectKey,
+                ContentType = stored.ContentType,
+                PublicUrl = stored.PublicUrl,
+                SortOrder = nextOrder,
+                PhysicalItemId = advertId
+            };
+
+            _context.Pictures.Add(picture);
+            await _context.SaveChangesAsync(ct);
+
+            advert.Pictures.Add(picture);
+            created.Add(new PictureDto(picture.PictureId, stored.PublicUrl, picture.SortOrder));
+        }
+
+        return Ok(created);
+    }
+
+    /// <summary>
+    /// Delete a specific image from an advert.
+    /// Only the advert owner or an admin can delete pictures.
+    /// </summary>
+    [HttpDelete("{pictureId:long}")]
+    public async Task<IActionResult> DeletePicture(
+        long advertId,
+        long pictureId,
+        CancellationToken ct = default)
+    {
+        var picture = await _context.Pictures
+            .Include(p => p.PhysicalItem)
+            .FirstOrDefaultAsync(p => p.PictureId == pictureId && p.PhysicalItemId == advertId, ct);
+
+        if (picture == null)
+            return NotFound(new { error = $"Image {pictureId} introuvable pour l'annonce {advertId}." });
+
+        var currentUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (picture.PhysicalItem.SellerId != currentUserId && !User.IsInRole("Admin"))
+            return Forbid();
+
+        if (!string.IsNullOrEmpty(picture.ObjectKey))
+        {
+            try
+            {
+                await _imageStorage.DeleteAsync(picture.ObjectKey, ct);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[MinIO] Failed to delete object {picture.ObjectKey}: {ex.Message}");
+            }
+        }
+
+        _context.Pictures.Remove(picture);
+        await _context.SaveChangesAsync(ct);
+
+        return NoContent();
+    }
+}

--- a/EcoScolarWebApi/Controllers/MeController.cs
+++ b/EcoScolarWebApi/Controllers/MeController.cs
@@ -129,7 +129,8 @@ public class MeController : ControllerBase
     {
         if (advert is PhysicalItem physicalItem && physicalItem.Pictures != null && physicalItem.Pictures.Any())
         {
-            return physicalItem.Pictures.First().Label;
+            var pic = physicalItem.Pictures.OrderBy(p => p.SortOrder).First();
+            return pic.PublicUrl ?? pic.Label;
         }
         return null;
     }

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertDto.cs
@@ -53,7 +53,8 @@ public record AdvertReadDto(long Id, string Type, string Title, decimal Price, D
 			_ => throw new InvalidOperationException("Unknown PhysicalItem type")
 		};
 
-		string? primaryImage = (entity as Models.PhysicalItem)?.Pictures?.FirstOrDefault()?.Label;
+		var pic = (entity as Models.PhysicalItem)?.Pictures?.OrderBy(p => p.SortOrder).FirstOrDefault();
+		string? primaryImage = pic?.PublicUrl ?? pic?.Label;
         // BuyerName is populated by the controller after joining with the Transaction table.
 
 		return new AdvertReadDto(

--- a/EcoScolarWebApi/DTOs/Adverts/AdvertSummaryDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/AdvertSummaryDto.cs
@@ -10,5 +10,6 @@ public record AdvertSummaryDto
 	public string? Category { get; set; }
 	public string? Subjects { get; set; }
 	public string? Grade { get; set; }
+	public string? ImageUrl { get; set; }
 	public string? sellerId { get; set; }
 }

--- a/EcoScolarWebApi/DTOs/Adverts/BookDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/BookDto.cs
@@ -27,7 +27,7 @@ public record BookReadDto(long id, string title, string description, decimal pri
 			publisher: entity.Publisher,
 			edition: entity.Edition,
 			writtenLanguage: entity.WrittenLanguage,
-			pictures: entity.Pictures?.Select(p => p.Label).ToList() ?? new List<string>()
+			pictures: entity.Pictures?.OrderBy(p => p.SortOrder).Select(p => p.PublicUrl ?? p.Label).ToList() ?? new List<string>()
 		);
 	}
 }

--- a/EcoScolarWebApi/DTOs/Adverts/PictureDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/PictureDto.cs
@@ -1,13 +1,3 @@
 ﻿namespace EcoScolarWebApi.DTOs.Adverts;
 
-/// <summary>
-/// DTO used to represent a Pictures in an PhysicalItem. 
-/// It contains the label of the Pictures, which is a string that describes the Pictures. 
-/// This DTO is used to transfer data between the application and the client, and it is also used to map the data from the database to the application.
-/// </summary>
-/// <param name="Label">The label of the Pictures</param>
-public record PictureDto(string Label)
-{
-    public static PictureDto FromEntity(Models.Picture entity) =>
-        new(Label: entity.Label);
-}
+public record PictureDto(long PictureId, string PublicUrl, int SortOrder);

--- a/EcoScolarWebApi/DTOs/Adverts/ProductDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/ProductDto.cs
@@ -23,7 +23,7 @@ public record ProductReadDto(long Id, string Title, string Description, decimal 
 			Weight: entity.Weight ?? null,
 			ProductCategoryId: entity.ProductCategoryId ?? null,
 			ProductCategoryLabel: entity.ProductCategory?.Name ?? null,
-			Pictures: entity.Pictures?.Select(p => p.Label).ToList() ?? []
+			Pictures: entity.Pictures?.OrderBy(p => p.SortOrder).Select(p => p.PublicUrl ?? p.Label).ToList() ?? []
 		);
 	}
 }
@@ -65,14 +65,10 @@ public record ProductCreateDto(string Title, string Description, decimal Price, 
 			product.Condition = Condition;
 			product.ProductCategoryId = ProductCategoryId;
 			product.Weight = Weight;
-            if (Images.IsNullOrEmpty())
+			if (!Images.IsNullOrEmpty())
 			{
-				product.Pictures.Add(new Picture { Label = "https://picsum.photos/800/600" });
+				product.Pictures = Images!.Select(img => new Picture { Label = img }).ToList();
 			}
-			else
-            {
-                product.Pictures = Images!.Select(img => new Picture { Label = img }).ToList();
-            }
 		}
 	}
 }

--- a/EcoScolarWebApi/DTOs/Adverts/ProductDto.cs
+++ b/EcoScolarWebApi/DTOs/Adverts/ProductDto.cs
@@ -71,7 +71,7 @@ public record ProductCreateDto(string Title, string Description, decimal Price, 
 			}
 			else
             {
-                product.Pictures = Images.Select(img => new Picture { Label = img }).ToList();
+                product.Pictures = Images!.Select(img => new Picture { Label = img }).ToList();
             }
 		}
 	}

--- a/EcoScolarWebApi/DTOs/Cart/CartItemDto.cs
+++ b/EcoScolarWebApi/DTOs/Cart/CartItemDto.cs
@@ -17,21 +17,21 @@ namespace EcoScolarWebApi.DTOs.Cart
         public long AdvertId { get; set; }
 
         [Required]
-        public string Type { get; set; }
+        public string Type { get; set; } = string.Empty;
 
         [Required]
-        public string Title { get; set; }
+        public string Title { get; set; } = string.Empty;
 
         [Required]
         public decimal Price { get; set; }
 
         [Required]
-        public string SellerPseudo { get; set; }
+        public string SellerPseudo { get; set; } = string.Empty;
 
         [Required]
         public string? PrimaryImage { get; set; }
 
         [Required]
-        public string Status { get; set; }
+        public string Status { get; set; } = string.Empty;
     }
 }   

--- a/EcoScolarWebApi/DTOs/ReferenceData/ProductCategoryCreateUpdateDto.cs
+++ b/EcoScolarWebApi/DTOs/ReferenceData/ProductCategoryCreateUpdateDto.cs
@@ -6,21 +6,21 @@ public class ProductCategoryCreateUpdateDto
 {
 	[Required]
 	[StringLength(100)]
-	public string Name { get; set; }
+	public string Name { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameFr { get; set; }
+    public string NameFr { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameDe { get; set; }
+    public string NameDe { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameIt { get; set; }
+    public string NameIt { get; set; } = string.Empty;
 
     [Required]
 	[StringLength(1000)]
-	public string Description { get; set; }
+	public string Description { get; set; } = string.Empty;
 }

--- a/EcoScolarWebApi/DTOs/ReferenceData/SchoolGradeCreateUpdateDto.cs
+++ b/EcoScolarWebApi/DTOs/ReferenceData/SchoolGradeCreateUpdateDto.cs
@@ -6,21 +6,21 @@ public class SchoolGradeCreateUpdateDto
 {
 	[Required]
 	[StringLength(100)]
-	public string Name { get; set; }
+	public string Name { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameFr { get; set; }
+    public string NameFr { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameDe { get; set; }
+    public string NameDe { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameIt { get; set; }
+    public string NameIt { get; set; } = string.Empty;
 
     [Required]
 	[StringLength(100)]
-	public string SchoolGrade { get; set; }
+	public string SchoolGrade { get; set; } = string.Empty;
 }

--- a/EcoScolarWebApi/DTOs/Users/UserDto.cs
+++ b/EcoScolarWebApi/DTOs/Users/UserDto.cs
@@ -58,11 +58,11 @@ public record UserReadDto(
     /// <returns>A UserReadDto populated with data from the specified Seller entity.</returns>
     public static UserReadDto FromEntity(User entity) => new(
         Id: entity.Id,
-        Nickname: entity.Nickname ?? "",
-        FirstName: entity.FirstName,
-        LastName: entity.LastName,
-        Email: entity.Email ?? "",
-        BirthdayDate: entity.DateOfBirth,
+        Nickname: entity.Nickname ?? string.Empty,
+        FirstName: entity.FirstName ?? string.Empty,
+        LastName: entity.LastName ?? string.Empty,
+        Email: entity.Email ?? string.Empty,
+        BirthdayDate: entity.DateOfBirth ?? string.Empty,
         IsOnboarded: entity.IsOnboarded,
         Location: entity.Location != null ? LocationReadDto.FromEntity(entity.Location) : null,
         Languages: entity.Languages != null
@@ -102,7 +102,7 @@ public record UserPublicReadDto(
 //[Required] int GlobalRating
 )
 {
-    public static UserPublicReadDto FromEntity(User user) => new UserPublicReadDto(user.Id, user.Nickname);
+    public static UserPublicReadDto FromEntity(User user) => new UserPublicReadDto(user.Id, user.Nickname ?? string.Empty);
 }
 public record LocationReadDto(
 string PostalCode,

--- a/EcoScolarWebApi/Data/DataSeeder.cs
+++ b/EcoScolarWebApi/Data/DataSeeder.cs
@@ -326,23 +326,6 @@ public class DataSeeder
 		context.Services.AddRange(services);
 		await context.SaveChangesAsync();
 
-        var pictures = new List<Picture>();
-        foreach (var item in physicalItems.Cast<PhysicalItem>().Concat(books))
-        {
-            var count = faker.Random.Int(1, 3);
-            for (var i = 1; i <= count; i++)
-            {
-                pictures.Add(new Picture
-                {
-                    Label = $"https://picsum.photos/seed/{item.AdvertId}-{i}/800/600",
-                    PhysicalItemId = item.AdvertId
-                });
-            }
-        }
-
-        context.Pictures.AddRange(pictures);
-        await context.SaveChangesAsync();
-
         var publicComments = new List<PublicComment>
         {
             new()

--- a/EcoScolarWebApi/Data/DataSeeder.cs
+++ b/EcoScolarWebApi/Data/DataSeeder.cs
@@ -6,7 +6,6 @@ using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
 using EcoScolarWebApi.Enums;
 using EcoScolarWebApi.Models;
-using EcoScolarWebApi.Enums;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -96,10 +95,10 @@ public class DataSeeder
 		public int PostalCode { get; set; }
 
 		[Name("City")]
-		public string City { get; set; }
+		public string City { get; set; } = string.Empty;
 
 		[Name("Region")]
-		public string Region { get; set; }
+		public string Region { get; set; } = string.Empty;
 	}
 
 	private static async Task SeedTestDataAsync(EcoscolarDbContext context, UserManager<User> userManager)

--- a/EcoScolarWebApi/Data/EcoscolarDbContext.cs
+++ b/EcoScolarWebApi/Data/EcoscolarDbContext.cs
@@ -24,7 +24,7 @@ public class EcoscolarDbContext(DbContextOptions<EcoscolarDbContext> options) : 
 	public DbSet<SchoolGrade> SchoolGrades { get; set; } = default!;
 	public DbSet<Subject> Subjects { get; set; } = default!;
 	public DbSet<BookCategory> BookCategories { get; set; } = default!;
-	public DbSet<User> Users { get; set; } = default!;
+	public new DbSet<User> Users { get; set; } = default!;
 	public DbSet<UserLanguage> UserLanguages { get; set; } = default!;
 	public DbSet<Language> Languages { get; set; } = default!;
 	public DbSet<Location> Locations { get; set; } = default!;

--- a/EcoScolarWebApi/Data/EcoscolarDbContext.cs
+++ b/EcoScolarWebApi/Data/EcoscolarDbContext.cs
@@ -24,7 +24,7 @@ public class EcoscolarDbContext(DbContextOptions<EcoscolarDbContext> options) : 
 	public DbSet<SchoolGrade> SchoolGrades { get; set; } = default!;
 	public DbSet<Subject> Subjects { get; set; } = default!;
 	public DbSet<BookCategory> BookCategories { get; set; } = default!;
-	public new DbSet<User> Users { get; set; } = default!;
+	public DbSet<User> Users { get; set; } = default!;
 	public DbSet<UserLanguage> UserLanguages { get; set; } = default!;
 	public DbSet<Language> Languages { get; set; } = default!;
 	public DbSet<Location> Locations { get; set; } = default!;

--- a/EcoScolarWebApi/EcoScolarWebApi.csproj
+++ b/EcoScolarWebApi/EcoScolarWebApi.csproj
@@ -41,6 +41,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Minio" Version="7.0.0" />
     <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
     <PackageReference Include="Stripe.net" Version="51.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
@@ -129,9 +129,9 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<IStripeConnectService, StripeConnectService>();
 
 		// MinIO image storage
-		var minioEndpoint = config["Minio:Endpoint"] ?? "localhost:9000";
-		var minioAccessKey = config["Minio:AccessKey"] ?? "ecoscolar";
-		var minioSecretKey = config["Minio:SecretKey"] ?? "ecoscolar_secret_change_me";
+		var minioEndpoint = config["Minio:Endpoint"].NullIfEmpty() ?? "localhost:9000";
+		var minioAccessKey = config["Minio:AccessKey"].NullIfEmpty() ?? "ecoscolar";
+		var minioSecretKey = config["Minio:SecretKey"].NullIfEmpty() ?? "ecoscolar_secret_change_me";
 		var minioUseHttps = config.GetValue("Minio:UseHttps", defaultValue: false);
 
 		services.AddMinio(configureClient => configureClient
@@ -144,4 +144,10 @@ public static class ServiceCollectionExtensions
 
         return services;
 	}
+}
+
+internal static class StringExtensions
+{
+    internal static string? NullIfEmpty(this string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
 }

--- a/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using EcoScolarWebApi.Services.Contracts;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi;
+using Minio;
 using Stripe;
 
 namespace EcoScolarWebApi.Extensions;
@@ -126,6 +127,20 @@ public static class ServiceCollectionExtensions
 		services.AddScoped<IAdminService, AdminService>();
 		services.AddScoped<ISupportContactService, SupportContactService>();
 		services.AddScoped<IStripeConnectService, StripeConnectService>();
+
+		// MinIO image storage
+		var minioEndpoint = config["Minio:Endpoint"] ?? "localhost:9000";
+		var minioAccessKey = config["Minio:AccessKey"] ?? "ecoscolar";
+		var minioSecretKey = config["Minio:SecretKey"] ?? "ecoscolar_secret_change_me";
+		var minioUseHttps = config.GetValue("Minio:UseHttps", defaultValue: false);
+
+		services.AddMinio(configureClient => configureClient
+			.WithEndpoint(minioEndpoint)
+			.WithCredentials(minioAccessKey, minioSecretKey)
+			.WithSSL(minioUseHttps)
+			.Build());
+
+		services.AddScoped<IImageStorageService, MinioImageStorageService>();
 
         return services;
 	}

--- a/EcoScolarWebApi/Helpers/NanoId.cs
+++ b/EcoScolarWebApi/Helpers/NanoId.cs
@@ -1,0 +1,24 @@
+using System.Security.Cryptography;
+
+namespace EcoScolarWebApi.Helpers;
+
+/// <summary>
+/// Lightweight NanoID generator — produces URL-safe random identifiers
+/// without any external dependency.
+/// </summary>
+internal static class NanoId
+{
+    private const string Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private const int DefaultSize = 10;
+
+    public static string Generate(int size = DefaultSize)
+    {
+        var chars = new char[size];
+        var bytes = RandomNumberGenerator.GetBytes(size);
+
+        for (var i = 0; i < size; i++)
+            chars[i] = Alphabet[bytes[i] % Alphabet.Length];
+
+        return new string(chars);
+    }
+}

--- a/EcoScolarWebApi/Migrations/20260614154901_AddPictureMinioFields.Designer.cs
+++ b/EcoScolarWebApi/Migrations/20260614154901_AddPictureMinioFields.Designer.cs
@@ -4,6 +4,7 @@ using EcoScolarWebApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EcoScolarWebApi.Migrations
 {
     [DbContext(typeof(EcoscolarDbContext))]
-    partial class EcoscolarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260614154901_AddPictureMinioFields")]
+    partial class AddPictureMinioFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EcoScolarWebApi/Migrations/20260614154901_AddPictureMinioFields.cs
+++ b/EcoScolarWebApi/Migrations/20260614154901_AddPictureMinioFields.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoScolarWebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPictureMinioFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ContentType",
+                table: "Pictures",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ObjectKey",
+                table: "Pictures",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PublicUrl",
+                table: "Pictures",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SortOrder",
+                table: "Pictures",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ContentType",
+                table: "Pictures");
+
+            migrationBuilder.DropColumn(
+                name: "ObjectKey",
+                table: "Pictures");
+
+            migrationBuilder.DropColumn(
+                name: "PublicUrl",
+                table: "Pictures");
+
+            migrationBuilder.DropColumn(
+                name: "SortOrder",
+                table: "Pictures");
+        }
+    }
+}

--- a/EcoScolarWebApi/Models/Book.cs
+++ b/EcoScolarWebApi/Models/Book.cs
@@ -8,19 +8,19 @@ public class Book : PhysicalItem
 {
     [Required]
     [StringLength(20)]
-    public string ISBN { get; set; }
+    public string ISBN { get; set; } = string.Empty;
 
     [Required]
     [StringLength(150)]
-    public string Author { get; set; }
+    public string Author { get; set; } = string.Empty;
 
     [Required]
     [StringLength(150)]
-    public string Publisher { get; set; }
+    public string Publisher { get; set; } = string.Empty;
 
     [Required]
     [StringLength(150)]
-    public string Edition { get; set; }
+    public string Edition { get; set; } = string.Empty;
 
     [Required]
     public Enums.LanguageEnum WrittenLanguage { get; set; }
@@ -29,5 +29,5 @@ public class Book : PhysicalItem
     public long BookCategoryId { get; set; }
 
     [ForeignKey("BookCategoryId")]
-    public virtual BookCategory BookCategory { get; set; }
+    public virtual BookCategory BookCategory { get; set; } = null!;
 }

--- a/EcoScolarWebApi/Models/BookCategory.cs
+++ b/EcoScolarWebApi/Models/BookCategory.cs
@@ -11,21 +11,21 @@ public class BookCategory
 
     [Required]
     [StringLength(100)]
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameFr { get; set; }
+    public string NameFr { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameDe { get; set; }
+    public string NameDe { get; set; } = string.Empty;
 
     [Required]
     [StringLength(100)]
-    public string NameIt { get; set; }
+    public string NameIt { get; set; } = string.Empty;
 
     [Required]
     [StringLength(1000)]
-    public string Description { get; set; }
+    public string Description { get; set; } = string.Empty;
 }

--- a/EcoScolarWebApi/Models/Flag.cs
+++ b/EcoScolarWebApi/Models/Flag.cs
@@ -18,10 +18,10 @@ public class Flag
     // === Foreign Keys ===
 
     [Required]
-    public string ReporterId { get; set; } 
+    public string ReporterId { get; set; } = string.Empty;
 
     [Required]
-    public string FlaggedId { get; set; }
+    public string FlaggedId { get; set; } = string.Empty;
 
     // === Navigation Properties ===
 

--- a/EcoScolarWebApi/Models/Language.cs
+++ b/EcoScolarWebApi/Models/Language.cs
@@ -8,19 +8,19 @@ namespace EcoScolarWebApi.Models;
 public class Language
 {
     [Key]
-    public string Label { get; set; }
+    public string Label { get; set; } = string.Empty;
 
     [Required]
-    public string Name { get; set; } // TODO - Rename in MCD Language -> Name
+    public string Name { get; set; } = string.Empty; // TODO - Rename in MCD Language -> Name
 
     [Required]
-    public string NameFr { get; set; }
+    public string NameFr { get; set; } = string.Empty;
 
     [Required]
-    public string NameDe { get; set; }
+    public string NameDe { get; set; } = string.Empty;
 
     [Required]
-    public string NameIt { get; set; }
+    public string NameIt { get; set; } = string.Empty;
 
     // === Many-to-many relationships ===
 

--- a/EcoScolarWebApi/Models/Picture.cs
+++ b/EcoScolarWebApi/Models/Picture.cs
@@ -9,9 +9,25 @@ public class Picture
     [Key]
     public long PictureId { get; set; }
 
+    /// <summary>Kept for backward compatibility. Use <see cref="PublicUrl"/> for new code.</summary>
     [Required]
     [StringLength(500)]
-    public string Label { get; set; }
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>MinIO object key, e.g. adverts/42/V1StGXR8.jpg</summary>
+    [StringLength(500)]
+    public string? ObjectKey { get; set; }
+
+    /// <summary>MIME type of the stored file, e.g. image/jpeg</summary>
+    [StringLength(50)]
+    public string? ContentType { get; set; }
+
+    /// <summary>Publicly accessible URL served from MinIO.</summary>
+    [StringLength(1000)]
+    public string? PublicUrl { get; set; }
+
+    /// <summary>Display order within the advert (0 = primary image).</summary>
+    public int SortOrder { get; set; }
 
     [Required]
     public long PhysicalItemId { get; set; }

--- a/EcoScolarWebApi/Models/TutoringAdvert.cs
+++ b/EcoScolarWebApi/Models/TutoringAdvert.cs
@@ -8,7 +8,7 @@ public class TutoringAdvert : Advert // TODO : Rename in MCD Services -> to Serv
 {
     [Required]
     [StringLength(50)]
-    public string StudyLevel { get; set; }
+    public string StudyLevel { get; set; } = string.Empty;
 
     [Required]
     public long SubjectId { get; set; }
@@ -21,8 +21,8 @@ public class TutoringAdvert : Advert // TODO : Rename in MCD Services -> to Serv
                                                              // A TutoringAdvert can be taught in multiple languages, so maybe we need a many-to-many relationship between TutoringAdvert and Language.
 
     [ForeignKey("SubjectId")]
-    public virtual Subject Subject { get; set; }
+    public virtual Subject Subject { get; set; } = null!;
 
     [ForeignKey("SchoolGradeId")]
-    public virtual SchoolGrade SchoolGrade { get; set; }
+    public virtual SchoolGrade SchoolGrade { get; set; } = null!;
 }

--- a/EcoScolarWebApi/Models/UserLanguage.cs
+++ b/EcoScolarWebApi/Models/UserLanguage.cs
@@ -5,11 +5,11 @@ namespace EcoScolarWebApi.Models;
 [Table("UserLanguages")]
 public class UserLanguage
 {
-    public string UserId { get; set; }
-    public User User { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public User User { get; set; } = null!;
 
-    public string Label { get; set; }
-    public Language Language { get; set; } 
+    public string Label { get; set; } = string.Empty;
+    public Language Language { get; set; } = null!;
 
-    public string LanguageLevel { get; set; }
+    public string LanguageLevel { get; set; } = string.Empty;
 }

--- a/EcoScolarWebApi/Services/AdminService.cs
+++ b/EcoScolarWebApi/Services/AdminService.cs
@@ -65,7 +65,7 @@ namespace EcoScolarWebApi.Services
                     m.UserId,
                     m.CreatedAt,
                     // On mappe l'utilisateur vers un DTO simplifié ou on extrait juste les infos nécessaires
-                    new UserAdminDto(m.User.FirstName, m.User.LastName, m.User.Nickname, m.User.Email),
+                    m.User != null ? new UserAdminDto(m.User.FirstName, m.User.LastName, m.User.Nickname, m.User.Email) : null,
                     // On projette chaque message de l'entité vers le DTO Message
                     m.Messages.Select(msg => new SupportTicketMessageAdminDto(
                         msg.Id,

--- a/EcoScolarWebApi/Services/AdvertSearchService.cs
+++ b/EcoScolarWebApi/Services/AdvertSearchService.cs
@@ -52,6 +52,9 @@ public sealed class AdvertSearchService : IAdvertSearchService
 
 		var bookAdvertIds = adverts.OfType<Book>().Select(b => b.AdvertId).Distinct().ToArray();
 		var serviceAdvertIds = adverts.OfType<TutoringAdvert>().Select(s => s.AdvertId).Distinct().ToArray();
+		var productAdvertIds = adverts.OfType<PhysicalItem>()
+			.Where(p => p is not Book)
+			.Select(p => p.AdvertId).Distinct().ToArray();
 
 		var booksDict = bookAdvertIds.Length == 0
 			? []
@@ -69,9 +72,16 @@ public sealed class AdvertSearchService : IAdvertSearchService
 				.Where(s => serviceAdvertIds.Contains(s.AdvertId))
 				.ToDictionaryAsync(s => s.AdvertId, cancellationToken);
 
+		var productsDict = productAdvertIds.Length == 0
+			? []
+			: await _context.Products.AsNoTracking()
+				.Include(p => p.Pictures)
+				.Where(p => productAdvertIds.Contains(p.AdvertId))
+				.ToDictionaryAsync(p => p.AdvertId, cancellationToken);
+
 		return new CatalogSummaryPageDto
 		{
-			Items = adverts.Select(a => MapSummary(a, booksDict, servicesDict)).ToList(),
+			Items = adverts.Select(a => MapSummary(a, booksDict, servicesDict, productsDict)).ToList(),
 			Page = page,
 			PageSize = pageSize,
 			TotalItems = totalItems,
@@ -275,7 +285,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 	private static AdvertSummaryDto MapSummary(
 		Advert a,
 		Dictionary<long, Book> booksDict,
-		Dictionary<long, TutoringAdvert> servicesDict)
+		Dictionary<long, TutoringAdvert> servicesDict,
+		Dictionary<long, PhysicalItem>? productsDict = null)
 	{
 		switch (a)
 		{
@@ -283,6 +294,7 @@ public sealed class AdvertSearchService : IAdvertSearchService
 				{
 					booksDict.TryGetValue(bk.AdvertId, out var fullBk);
 					var src = fullBk ?? bk;
+					var primaryPic = src.Pictures?.OrderBy(p => p.SortOrder).FirstOrDefault();
 					return new AdvertSummaryDto
 					{
 						Id = bk.AdvertId,
@@ -293,6 +305,7 @@ public sealed class AdvertSearchService : IAdvertSearchService
 						Category = src.BookCategory?.Name,
 						Subjects = null,
 						Grade = null,
+						ImageUrl = primaryPic?.PublicUrl ?? primaryPic?.Label,
 						sellerId = bk.SellerId
 					};
 				}
@@ -310,22 +323,30 @@ public sealed class AdvertSearchService : IAdvertSearchService
 						Category = null,
 						Subjects = src.Subject?.Name,
 						Grade = src.SchoolGrade?.Name,
+						ImageUrl = null,
 						sellerId = svc.SellerId
 					};
 				}
 			case PhysicalItem phy when phy is not Book:
-				return new AdvertSummaryDto
 				{
-					Id = phy.AdvertId,
-					Title = phy.Title,
-					Price = phy.Price,
-					Type = CatalogAdvertTypeCodes.Product,
-					Isbn = null,
-					Category = null,
-					Subjects = null,
-					Grade = null,
-					sellerId = phy.SellerId
-				};
+					var srcPhy = productsDict != null && productsDict.TryGetValue(phy.AdvertId, out var fullPhy)
+						? fullPhy
+						: phy;
+					var primaryPic = srcPhy.Pictures?.OrderBy(p => p.SortOrder).FirstOrDefault();
+					return new AdvertSummaryDto
+					{
+						Id = phy.AdvertId,
+						Title = phy.Title,
+						Price = phy.Price,
+						Type = CatalogAdvertTypeCodes.Product,
+						Isbn = null,
+						Category = null,
+						Subjects = null,
+						Grade = null,
+						ImageUrl = primaryPic?.PublicUrl ?? primaryPic?.Label,
+						sellerId = phy.SellerId
+					};
+				}
 			default:
 				throw new InvalidOperationException($"Unknown PhysicalItem CLR type '{a.GetType().Name}'.");
 		}
@@ -333,7 +354,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 
 	private static AdvertDetailDto ToDetailFromBook(Book b)
 	{
-		string? imageUrl = b.Pictures?.FirstOrDefault()?.Label;
+		var primaryPic = b.Pictures?.OrderBy(p => p.SortOrder).FirstOrDefault();
+		string? imageUrl = primaryPic?.PublicUrl ?? primaryPic?.Label;
 
 		return new AdvertDetailDto
 		{
@@ -371,7 +393,8 @@ public sealed class AdvertSearchService : IAdvertSearchService
 
 	private static AdvertDetailDto ToDetailFromPhysical(PhysicalItem p)
 	{
-		string? imageUrl = p.Pictures?.FirstOrDefault()?.Label;
+		var primaryPic = p.Pictures?.OrderBy(p => p.SortOrder).FirstOrDefault();
+		string? imageUrl = primaryPic?.PublicUrl ?? primaryPic?.Label;
 		return new AdvertDetailDto
 		{
 			Id = p.AdvertId,

--- a/EcoScolarWebApi/Services/CartService.cs
+++ b/EcoScolarWebApi/Services/CartService.cs
@@ -21,7 +21,7 @@ namespace EcoScolarWebApi.Services
         {
             var cartItems = await _context.CartItems
                 .Include(c => c.Advert)
-                    .ThenInclude(a => a.Seller)
+                    .ThenInclude(a => a.Seller!)
                 .Where(c => c.UserId == userId)
                 .ToListAsync();
 

--- a/EcoScolarWebApi/Services/CartService.cs
+++ b/EcoScolarWebApi/Services/CartService.cs
@@ -35,7 +35,8 @@ namespace EcoScolarWebApi.Services
 
             var dtos = cartItems.Select(c =>
             {
-                var primaryImage = _context.Pictures.FirstOrDefault(p => p.PhysicalItemId == c.AdvertId)?.Label;
+                var pic = _context.Pictures.Where(p => p.PhysicalItemId == c.AdvertId).OrderBy(p => p.SortOrder).FirstOrDefault();
+                var primaryImage = pic?.PublicUrl ?? pic?.Label;
                 
                 string type = c.Advert switch
                 {
@@ -103,10 +104,11 @@ namespace EcoScolarWebApi.Services
             await _context.SaveChangesAsync();
 
             // Get main picture of the advert
-            var primaryImage = await _context.Pictures
+            var primaryPic = await _context.Pictures
                 .Where(p => p.PhysicalItemId == dto.AdvertId)
-                .Select(p => p.Label)
+                .OrderBy(p => p.SortOrder)
                 .FirstOrDefaultAsync();
+            var primaryImage = primaryPic?.PublicUrl ?? primaryPic?.Label;
 
             string type = advert switch
             {

--- a/EcoScolarWebApi/Services/Contracts/IImageStorageService.cs
+++ b/EcoScolarWebApi/Services/Contracts/IImageStorageService.cs
@@ -1,0 +1,12 @@
+namespace EcoScolarWebApi.Services.Contracts;
+
+public record StoredImageResult(string ObjectKey, string PublicUrl, string ContentType);
+
+public interface IImageStorageService
+{
+    /// <summary>Upload a validated image file and return its storage metadata.</summary>
+    Task<StoredImageResult> UploadAsync(IFormFile file, string folder, CancellationToken ct = default);
+
+    /// <summary>Delete a stored image by its object key.</summary>
+    Task DeleteAsync(string objectKey, CancellationToken ct = default);
+}

--- a/EcoScolarWebApi/Services/MinioImageStorageService.cs
+++ b/EcoScolarWebApi/Services/MinioImageStorageService.cs
@@ -1,0 +1,104 @@
+using EcoScolarWebApi.Helpers;
+using EcoScolarWebApi.Services.Contracts;
+using Minio;
+using Minio.DataModel.Args;
+
+namespace EcoScolarWebApi.Services;
+
+public class MinioImageStorageService : IImageStorageService
+{
+    private const long MaxFileSizeBytes = 5 * 1024 * 1024; // 5 MB
+
+    private static readonly HashSet<string> AllowedMimeTypes =
+        ["image/jpeg", "image/png", "image/webp"];
+
+    private static readonly Dictionary<string, string> MimeToExtension = new()
+    {
+        ["image/jpeg"] = "jpg",
+        ["image/png"] = "png",
+        ["image/webp"] = "webp"
+    };
+
+    private readonly IMinioClient _minio;
+    private readonly string _bucket;
+    private readonly string _publicBaseUrl;
+
+    public MinioImageStorageService(IMinioClient minio, IConfiguration config)
+    {
+        _minio = minio;
+        _bucket = config["Minio:Bucket"] ?? "ecoscolar-adverts";
+        _publicBaseUrl = config["Minio:PublicBaseUrl"]?.TrimEnd('/') ?? "http://localhost:9000/ecoscolar-adverts";
+    }
+
+    public async Task<StoredImageResult> UploadAsync(IFormFile file, string folder, CancellationToken ct = default)
+    {
+        var contentType = file.ContentType?.ToLowerInvariant();
+
+        if (string.IsNullOrWhiteSpace(contentType) || !AllowedMimeTypes.Contains(contentType))
+            throw new InvalidOperationException($"Type de fichier non autorisé : {contentType}. Formats acceptés : JPEG, PNG, WebP.");
+
+        if (file.Length > MaxFileSizeBytes)
+            throw new InvalidOperationException($"Le fichier dépasse la taille maximale autorisée de 5 Mo.");
+
+        if (file.Length == 0)
+            throw new InvalidOperationException("Le fichier est vide.");
+
+        var ext = MimeToExtension[contentType];
+        var fileName = $"{NanoId.Generate()}.{ext}";
+        var objectKey = $"{folder.TrimEnd('/')}/{fileName}";
+
+        await EnsureBucketExistsAsync(ct);
+
+        using var stream = file.OpenReadStream();
+        var putArgs = new PutObjectArgs()
+            .WithBucket(_bucket)
+            .WithObject(objectKey)
+            .WithStreamData(stream)
+            .WithObjectSize(file.Length)
+            .WithContentType(contentType);
+
+        await _minio.PutObjectAsync(putArgs, ct);
+
+        var publicUrl = $"{_publicBaseUrl}/{objectKey}";
+        return new StoredImageResult(objectKey, publicUrl, contentType);
+    }
+
+    public async Task DeleteAsync(string objectKey, CancellationToken ct = default)
+    {
+        var removeArgs = new RemoveObjectArgs()
+            .WithBucket(_bucket)
+            .WithObject(objectKey);
+
+        await _minio.RemoveObjectAsync(removeArgs, ct);
+    }
+
+    private async Task EnsureBucketExistsAsync(CancellationToken ct)
+    {
+        var exists = await _minio.BucketExistsAsync(
+            new BucketExistsArgs().WithBucket(_bucket), ct);
+
+        if (!exists)
+        {
+            await _minio.MakeBucketAsync(
+                new MakeBucketArgs().WithBucket(_bucket), ct);
+
+            // Set the bucket to public read so images are accessible without signing
+            var policy = $$"""
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {"AWS": ["*"]},
+                      "Action": ["s3:GetObject"],
+                      "Resource": ["arn:aws:s3:::{{_bucket}}/*"]
+                    }
+                  ]
+                }
+                """;
+
+            await _minio.SetPolicyAsync(
+                new SetPolicyArgs().WithBucket(_bucket).WithPolicy(policy), ct);
+        }
+    }
+}

--- a/EcoScolarWebApi/appsettings.Development.json
+++ b/EcoScolarWebApi/appsettings.Development.json
@@ -22,5 +22,13 @@
   },
   "Support": {
     "DestinationEmail": "support@ecoscolar.local"
+  },
+  "Minio": {
+    "Endpoint": "localhost:9000",
+    "AccessKey": "ecoscolar",
+    "SecretKey": "ecoscolar_secret_change_me",
+    "Bucket": "ecoscolar-adverts",
+    "PublicBaseUrl": "http://localhost:9000/ecoscolar-adverts",
+    "UseHttps": false
   }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,11 @@ services:
       Stripe__SecretKey: ${STRIPE_SECRET_KEY}
       Smtp__Host: ecoscolar-mailpit
       Smtp__Port: 1025
+      Minio__Endpoint: ecoscolar-minio:9000
+      Minio__AccessKey: ${MINIO_ACCESS_KEY}
+      Minio__SecretKey: ${MINIO_SECRET_KEY}
+      Minio__Bucket: ${MINIO_BUCKET}
+      Minio__PublicBaseUrl: ${MINIO_PUBLIC_BASE_URL}
     networks:
       - dmz
       - ecoscolar
@@ -73,6 +78,32 @@ services:
       retries: 5
 
   # -----------------------------
+  # MinIO - S3-compatible local object storage
+  # -----------------------------
+  ecoscolar-minio:
+    image: minio/minio:latest
+    container_name: ecoscolar-minio
+    command: server /data --console-address ":9001"
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY}
+    volumes:
+      - minio-ecoscolar-data:/data
+    networks:
+      - ecoscolar
+      - dmz
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # -----------------------------
   # Mailpit - SMTP Server and Web UI for Testing Emails
   # -----------------------------
   ecoscolar-mailpit:
@@ -100,3 +131,4 @@ networks:
 
 volumes:
   mssql-ecoscolar-data:
+  minio-ecoscolar-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
+      MSSQL_TCP_PORT: "1444"
     volumes:
       - mssql-ecoscolar-data:/var/opt/mssql
     networks:
@@ -15,7 +16,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P \"${MSSQL_SA_PASSWORD}\" -Q \"SELECT 1\" || exit 1"
+          "/opt/mssql-tools18/bin/sqlcmd -C -S localhost,1444 -U sa -P \"${MSSQL_SA_PASSWORD}\" -Q \"SELECT 1\" || exit 1"
         ]
       interval: 5s
       timeout: 5s
@@ -32,8 +33,10 @@ services:
         condition: service_healthy
     environment:
       ASPNETCORE_HTTP_PORTS: "8080"
+      ASPNETCORE_ENVIRONMENT: "Production"
       ApplyDatabaseMigrations: "true"
-      ConnectionStrings__Default: "Server=ecoscolar-api-database,1433;Initial Catalog=ecoscolar;User ID=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True;Encrypt=True"
+      Features__UseFakeAdvertSearch: "false"
+      ConnectionStrings__Default: "Server=ecoscolar-api-database,1444;Initial Catalog=ecoscolar;User ID=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True;Encrypt=True"
       Stripe__SecretKey: ${STRIPE_SECRET_KEY}
       Smtp__Host: ecoscolar-mailpit
       Smtp__Port: 1025

--- a/sample.env
+++ b/sample.env
@@ -6,6 +6,13 @@ MSSQL_SA_PASSWORD=
 
 STRIPE_SECRET_KEY=
 
+# ===== MinIO local object storage =====
+MINIO_ACCESS_KEY=ecoscolar
+MINIO_SECRET_KEY=ecoscolar_secret_change_me
+MINIO_BUCKET=ecoscolar-adverts
+# Public base URL used by the API to build image URLs returned to clients
+MINIO_PUBLIC_BASE_URL=http://localhost:9000/ecoscolar-adverts
+
 # ===== Production database seed =====
 # Used by scripts/seed-production-db.ps1. Keep real values only in .env or shell env vars.
 ECOSCOLAR_SEED_ADMIN_EMAIL=


### PR DESCRIPTION
## Summary
- Correction de tous les endpoints qui utilisaient `Label` (clé objet MinIO) au lieu de
  `PublicUrl` (URL publique complète) pour retourner les images :
  `AdvertDto`, `CartService` (x2), `MeController.GetPrimaryImage`,
  `ProductDto.Pictures`, `BookDto.Pictures`
- Suppression du fallback picsum automatique dans `ProductCreateDto.MapToEntity` :
  les images sont désormais exclusivement uploadées via MinIO par l'utilisateur,
  plus aucune image placeholder n'est créée à la création d'une annonce