### PR TITLE
feat: generate human-readable order number on transaction creation

### DIFF
--- a/EcoScolarWebApi/Controllers/PaymentsController.cs
+++ b/EcoScolarWebApi/Controllers/PaymentsController.cs
@@ -117,7 +117,7 @@ public class PaymentsController : ControllerBase
 				TransferGroup = "COMMANDE_ID_789",
 			},
 
-            SuccessUrl = $"{baseUrl}/success?orderId={{CHECKOUT_SESSION_ID}}&productIds={productIdsQuery}&productId={productIds[0]}",
+            SuccessUrl = $"{baseUrl}/success?stripeSessionId={{CHECKOUT_SESSION_ID}}&productIds={productIdsQuery}&productId={productIds[0]}",
             CancelUrl = $"{baseUrl}/denied?productIds={productIdsQuery}",
 		};
 

--- a/EcoScolarWebApi/Controllers/TransactionsController.cs
+++ b/EcoScolarWebApi/Controllers/TransactionsController.cs
@@ -8,6 +8,7 @@ using EcoScolarWebApi.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Cryptography;
 
 namespace EcoScolarWebApi.Controllers;
 
@@ -178,16 +179,26 @@ public class TransactionsController(EcoscolarDbContext context, UserManager<User
 			return BadRequest(new { message = "AdvertIds are required." });
 		}
 
+		var existingOrderNumber = await _context.Transactions
+			.Where(t => request.AdvertIds.Contains(t.AdvertId) && t.OrderNumber != null)
+			.Select(t => t.OrderNumber)
+			.FirstOrDefaultAsync();
+
+		var orderNumber = existingOrderNumber ?? await GenerateUniqueOrderNumberAsync();
+
 		var createdTransactions = new List<Transaction>();
 
 		foreach (var advertId in request.AdvertIds)
 		{
-			// Check if a transaction already exists for this advert
 			var existingTransaction = await _context.Transactions
 				.FirstOrDefaultAsync(t => t.AdvertId == advertId);
 
 			if (existingTransaction != null)
 			{
+				if (string.IsNullOrWhiteSpace(existingTransaction.OrderNumber))
+				{
+					existingTransaction.OrderNumber = orderNumber;
+				}
 				createdTransactions.Add(existingTransaction);
 				continue;
 			}
@@ -198,7 +209,6 @@ public class TransactionsController(EcoscolarDbContext context, UserManager<User
 				return NotFound(new { message = $"Advert with ID {advertId} not found." });
 			}
 
-			// Calculate platform fee (5% of price, rounded to 2 decimal places)
 			var platformFee = Math.Round(advert.Price * 0.05m, 2);
 
 			var newTransaction = new Transaction
@@ -208,12 +218,12 @@ public class TransactionsController(EcoscolarDbContext context, UserManager<User
 				Date = DateTime.UtcNow,
 				Status = TransactionStatus.PAID_WAITING_SHIPPING,
 				PlatformFee = platformFee,
+				OrderNumber = orderNumber,
 				StripeSessionId = request.StripeSessionId,
 				BuyerConsent = false,
 				SellerConsent = false
 			};
 
-			// Update the advert status to SOLD
 			advert.Status = AdvertStatus.SOLD;
 			_context.Entry(advert).State = EntityState.Modified;
 
@@ -230,8 +240,20 @@ public class TransactionsController(EcoscolarDbContext context, UserManager<User
 			t.Status,
 			t.Date,
 			t.PlatformFee,
+			t.OrderNumber,
 			t.StripeSessionId
 		}));
+	}
+
+	private async Task<string> GenerateUniqueOrderNumberAsync()
+	{
+		string orderNumber;
+		do
+		{
+			orderNumber = $"ECO-{DateTime.UtcNow:yyyyMMdd}-{RandomNumberGenerator.GetInt32(0, 1_000_000):D6}";
+		}
+		while (await _context.Transactions.AnyAsync(t => t.OrderNumber == orderNumber));
+		return orderNumber;
 	}
 }
 

--- a/EcoScolarWebApi/Data/EcoscolarDbContext.cs
+++ b/EcoScolarWebApi/Data/EcoscolarDbContext.cs
@@ -1,4 +1,4 @@
-using EcoScolarWebApi.Models;
+﻿using EcoScolarWebApi.Models;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
@@ -120,6 +120,11 @@ public class EcoscolarDbContext(DbContextOptions<EcoscolarDbContext> options) : 
 				.WithMany()
 				.HasForeignKey(t => t.BuyerId)
 				.OnDelete(DeleteBehavior.Restrict);
+				
+			entity.Property(t => t.OrderNumber)
+				.HasMaxLength(32);
+
+			entity.HasIndex(t => t.OrderNumber);
 		});
 
 		// PublicComment

--- a/EcoScolarWebApi/Migrations/20260615090535_AddOrderNumberToTransactions.Designer.cs
+++ b/EcoScolarWebApi/Migrations/20260615090535_AddOrderNumberToTransactions.Designer.cs
@@ -4,6 +4,7 @@ using EcoScolarWebApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EcoScolarWebApi.Migrations
 {
     [DbContext(typeof(EcoscolarDbContext))]
-    partial class EcoscolarDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615090535_AddOrderNumberToTransactions")]
+    partial class AddOrderNumberToTransactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EcoScolarWebApi/Migrations/20260615090535_AddOrderNumberToTransactions.cs
+++ b/EcoScolarWebApi/Migrations/20260615090535_AddOrderNumberToTransactions.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EcoScolarWebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderNumberToTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OrderNumber",
+                table: "Transactions",
+                type: "nvarchar(32)",
+                maxLength: 32,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Transactions_OrderNumber",
+                table: "Transactions",
+                column: "OrderNumber");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Transactions_OrderNumber",
+                table: "Transactions");
+
+            migrationBuilder.DropColumn(
+                name: "OrderNumber",
+                table: "Transactions");
+        }
+    }
+}

--- a/EcoScolarWebApi/Models/Transaction.cs
+++ b/EcoScolarWebApi/Models/Transaction.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using EcoScolarWebApi.Enums;
 
@@ -9,6 +9,9 @@ public class Transaction
 {
     [Key]
     public long TransactionId { get; set; }
+
+    [MaxLength(32)]
+    public string? OrderNumber { get; set; }
 
     [Required]
     public long AdvertId { get; set; }


### PR DESCRIPTION
Ajoute un champ OrderNumber (format ECO-YYYYMMDD-XXXXXX) sur le modèle Transaction, généré automatiquement à la création et garanti unique en base. Le TransferGroup Stripe et le paramètre stripeSessionId dans l'URL de succès sont conservés pour la traçabilité interne. Migration EF Core incluse.