### PR TITLE
Feature/tutoring reserve

### DIFF
--- a/EcoScolarWebApi.Tests/AdvertTest.cs
+++ b/EcoScolarWebApi.Tests/AdvertTest.cs
@@ -1559,12 +1559,14 @@ public class AdvertsControllerTests : IDisposable
         var serviceCreateDto = new ServiceCreateDto(
             Title: "New Service",
             Description: "Description of the new service",
-            Price: 20m,
+            PricePerHour: 20m,
             UserId: existingUser.Id,
             SubjectId: 1,
             SchoolGradeId: 1,
             TeachingLanguage: LanguageEnum.FR,
-            StudyLevel: "Diplôme en Mathématiques"
+            StudyLevel: "Diplôme en Mathématiques",
+            MinHours: 1,
+            MaxHours: 8
         );
 
         // Act
@@ -1597,12 +1599,14 @@ public class AdvertsControllerTests : IDisposable
         var serviceCreateDto = new ServiceCreateDto(
             Title: "", // Invalid
             Description: "Description of the new service",
-            Price: 20m,
+            PricePerHour: 20m,
             UserId: existingUser.Id,
             SubjectId: 1,
             SchoolGradeId: 1,
             TeachingLanguage: LanguageEnum.FR,
-            StudyLevel: "Diplôme en Mathématiques"
+            StudyLevel: "Diplôme en Mathématiques",
+            MinHours: 1,
+            MaxHours: 8
         );
 
         // FORCE VALIDATION ERROR
@@ -1978,13 +1982,14 @@ public class AdvertsControllerTests : IDisposable
         var serviceUpdateDto = new ServiceCreateDto(
             Title: "Lesson de français",
             Description: "Cours de français pour lycéens",
-            Price: 40m,
+            PricePerHour: 40m,
             UserId: existingUser.Id,
             SubjectId: 2,
             SchoolGradeId: 1,
             TeachingLanguage: LanguageEnum.FR,
-            StudyLevel: "Diplôme en Langue Française"
-
+            StudyLevel: "Diplôme en Langue Française",
+            MinHours: 1,
+            MaxHours: 8
         );
 
         // Act
@@ -2036,13 +2041,14 @@ public class AdvertsControllerTests : IDisposable
         var serviceUpdateDto = new ServiceCreateDto(
             Title: "", // Invalid
             Description: "Cours de français pour lycéens",
-            Price: 40m,
+            PricePerHour: 40m,
             UserId: existingUser.Id,
             SubjectId: 1,
             SchoolGradeId: 1,
             TeachingLanguage: LanguageEnum.FR,
-            StudyLevel: "Diplôme en Langue Française"
-
+            StudyLevel: "Diplôme en Langue Française",
+            MinHours: 1,
+            MaxHours: 8
         );
 
         _controller.ModelState.AddModelError("Title", "The Title field is required.");
@@ -2067,13 +2073,14 @@ public class AdvertsControllerTests : IDisposable
         var serviceUpdateDto = new ServiceCreateDto(
             Title: "Lesson de français",
             Description: "Cours de français pour lycéens",
-            Price: 40m,
+            PricePerHour: 40m,
             UserId: existingUser.Id,
             SubjectId: 1,
             SchoolGradeId: 1,
             TeachingLanguage: LanguageEnum.FR,
-            StudyLevel: "Diplôme en Langue Française"
-
+            StudyLevel: "Diplôme en Langue Française",
+            MinHours: 1,
+            MaxHours: 8
         );
 
         // Act

--- a/EcoScolarWebApi.Tests/Unit/Controllers/PaymentsControllerTests.cs
+++ b/EcoScolarWebApi.Tests/Unit/Controllers/PaymentsControllerTests.cs
@@ -1,350 +1,108 @@
+using EcoScolarWebApi.Commun;
 using EcoScolarWebApi.Controllers;
-using EcoScolarWebApi.Data;
 using EcoScolarWebApi.DTOs.Stripe;
-using EcoScolarWebApi.Enums;
 using EcoScolarWebApi.Models;
+using EcoScolarWebApi.Services.Contracts;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
 namespace EcoScolarWebApi.Tests.Unit.Controllers;
 
-public class PaymentsControllerTests : IDisposable
+/// <summary>
+/// The controller is a thin delegator to <see cref="IPaymentService"/>; the checkout business
+/// logic (server-side pricing, pausing, idempotent webhook) is covered by PaymentServiceTests.
+/// These tests only verify the HTTP mapping.
+/// </summary>
+public class PaymentsControllerTests
 {
-	private readonly EcoscolarDbContext _context;
-	private readonly IConfiguration _configMock;
-	private readonly PaymentsController _controller;
+    private const string BuyerId = "buyer-1";
 
-	public PaymentsControllerTests()
-	{
-		var options = new DbContextOptionsBuilder<EcoscolarDbContext>()
-			.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-			.Options;
-		_context = new EcoscolarDbContext(options);
-		_configMock = Substitute.For<IConfiguration>();
-		_configMock["Stripe:SecretKey"].Returns("sk_test_mock");
-		_configMock["Stripe:WebhookSecret"].Returns((string?)null);
+    private readonly IPaymentService _paymentService;
+    private readonly UserManager<User> _userManager;
+    private readonly PaymentsController _controller;
 
-		_controller = new PaymentsController(_configMock, _context);
+    public PaymentsControllerTests()
+    {
+        _paymentService = Substitute.For<IPaymentService>();
 
-		// Set up a default HttpContext with required properties
-		var httpContext = new DefaultHttpContext();
-		httpContext.Request.Scheme = "https";
-		httpContext.Request.Host = new HostString("localhost", 5001);
-		_controller.ControllerContext = new ControllerContext
-		{
-			HttpContext = httpContext
-		};
-	}
+        var store = Substitute.For<IUserStore<User>>();
+        _userManager = Substitute.For<UserManager<User>>(store, null!, null!, null!, null!, null!, null!, null!, null!);
+        _userManager.GetUserId(Arg.Any<System.Security.Claims.ClaimsPrincipal>()).Returns(BuyerId);
 
-	public void Dispose()
-	{
-		_context.Database.EnsureDeleted();
-		_context.Dispose();
-		GC.SuppressFinalize(this);
-	}
+        var config = Substitute.For<IConfiguration>();
 
-	#region Checkout Tests
+        _controller = new PaymentsController(config, _paymentService, _userManager, Substitute.For<ILogger<PaymentsController>>())
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    Request = { Scheme = "https", Host = new HostString("localhost", 5001) }
+                }
+            }
+        };
+    }
 
-	[Fact]
-	public async Task Checkout_ShouldReturnNotFound_WhenProductDoesNotExist()
-	{
-		// Arrange
-		var request = new CheckoutRequestDto
-		{
-			ProductIds = new List<long> { 999L },
-			ProductPrice = 10.0,
-			ShippingMethod = "handToHand"
-		};
+    private CheckoutRequestDto Request() => new() { ProductIds = new List<long> { 1L }, ShippingMethod = "handToHand" };
 
-		// Act
-		var result = await _controller.Checkout(request);
+    [Fact]
+    public async Task Checkout_ReturnsOk_WhenServiceSucceeds()
+    {
+        _paymentService.CreateCheckoutSessionAsync(Arg.Any<CheckoutRequestDto>(), BuyerId, Arg.Any<string>())
+            .Returns(Result<CheckoutSessionResultDto>.Success(new CheckoutSessionResultDto("https://stripe.test/checkout", "ECO-1")));
 
-		// Assert
-		result.Should().BeOfType<NotFoundObjectResult>();
-	}
+        var result = await _controller.Checkout(Request());
 
-	[Fact]
-	public async Task Checkout_ShouldReturnBadRequest_WhenProductIsSold()
-	{
-		// Arrange
-		var book = new Book
-		{
-			AdvertId = 1,
-			Title = "Sold Book",
-			Description = "Already sold",
-			Price = 20m,
-			SellerId = "seller-1",
-			ISBN = "12345",
-			Author = "Author",
-			Publisher = "Pub",
-			Edition = "1st",
-			WrittenLanguage = LanguageEnum.FR,
-			Status = AdvertStatus.SOLD
-		};
-		_context.Products.Add(book);
-		await _context.SaveChangesAsync();
+        result.Should().BeOfType<OkObjectResult>();
+    }
 
-		var request = new CheckoutRequestDto
-		{
-			ProductIds = new List<long> { 1L },
-			ProductPrice = 20.0,
-			ShippingMethod = "handToHand"
-		};
+    [Fact]
+    public async Task Checkout_ReturnsUnauthorized_WhenNoAuthenticatedUser()
+    {
+        _userManager.GetUserId(Arg.Any<System.Security.Claims.ClaimsPrincipal>()).Returns((string?)null);
 
-		// Act
-		var result = await _controller.Checkout(request);
+        var result = await _controller.Checkout(Request());
 
-		// Assert
-		result.Should().BeOfType<BadRequestObjectResult>();
-	}
+        result.Should().BeOfType<UnauthorizedResult>();
+    }
 
-	[Fact]
-	public async Task Checkout_ShouldReturnBadRequest_WhenProductIsPaused()
-	{
-		// Arrange
-		var book = new Book
-		{
-			AdvertId = 2,
-			Title = "Paused Book",
-			Description = "Being paid for",
-			Price = 30m,
-			SellerId = "seller-1",
-			ISBN = "12345",
-			Author = "Author",
-			Publisher = "Pub",
-			Edition = "1st",
-			WrittenLanguage = LanguageEnum.FR,
-			Status = AdvertStatus.PAUSED
-		};
-		_context.Products.Add(book);
-		await _context.SaveChangesAsync();
+    [Fact]
+    public async Task Checkout_ReturnsNotFound_WhenServiceReturnsNotFound()
+    {
+        _paymentService.CreateCheckoutSessionAsync(Arg.Any<CheckoutRequestDto>(), BuyerId, Arg.Any<string>())
+            .Returns(Result<CheckoutSessionResultDto>.Failure("missing", ErrorType.NotFound));
 
-		var request = new CheckoutRequestDto
-		{
-			ProductIds = new List<long> { 2L },
-			ProductPrice = 30.0,
-			ShippingMethod = "handToHand"
-		};
+        var result = await _controller.Checkout(Request());
 
-		// Act
-		var result = await _controller.Checkout(request);
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
 
-		// Assert
-		result.Should().BeOfType<BadRequestObjectResult>();
-	}
+    [Fact]
+    public async Task Checkout_ReturnsConflict_WhenServiceReturnsConflict()
+    {
+        _paymentService.CreateCheckoutSessionAsync(Arg.Any<CheckoutRequestDto>(), BuyerId, Arg.Any<string>())
+            .Returns(Result<CheckoutSessionResultDto>.Failure("unavailable", ErrorType.Conflict));
 
-	[Fact]
-	public async Task Checkout_ShouldReturnNotFound_WhenOneOfMultipleProductsMissing()
-	{
-		// Arrange
-		var book = new Book
-		{
-			AdvertId = 3,
-			Title = "Existing Book",
-			Description = "A book",
-			Price = 15m,
-			SellerId = "seller-1",
-			ISBN = "12345",
-			Author = "Author",
-			Publisher = "Pub",
-			Edition = "1st",
-			WrittenLanguage = LanguageEnum.FR,
-			Status = AdvertStatus.ACTIVE
-		};
-		_context.Products.Add(book);
-		await _context.SaveChangesAsync();
+        var result = await _controller.Checkout(Request());
 
-		var request = new CheckoutRequestDto
-		{
-			ProductIds = new List<long> { 3L, 999L },
-			ProductPrice = 15.0,
-			ShippingMethod = "handToHand"
-		};
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
 
-		// Act
-		var result = await _controller.Checkout(request);
+    [Fact]
+    public async Task Checkout_ReturnsBadGateway_WhenServiceReturnsInternalError()
+    {
+        _paymentService.CreateCheckoutSessionAsync(Arg.Any<CheckoutRequestDto>(), BuyerId, Arg.Any<string>())
+            .Returns(Result<CheckoutSessionResultDto>.Failure("stripe down", ErrorType.InternalError));
 
-		// Assert
-		result.Should().BeOfType<NotFoundObjectResult>();
-	}
+        var result = await _controller.Checkout(Request());
 
-	[Fact]
-	public async Task Checkout_ShouldFallbackToProductId_WhenProductIdsIsEmpty()
-	{
-		// Arrange — single product not found via fallback ProductId
-		var request = new CheckoutRequestDto
-		{
-			ProductId = 999,
-			ProductIds = new List<long>(),
-			ProductPrice = 10.0,
-			ShippingMethod = "handToHand"
-		};
-
-		// Act
-		var result = await _controller.Checkout(request);
-
-		// Assert
-		result.Should().BeOfType<NotFoundObjectResult>();
-	}
-
-	#endregion
-
-	#region Shipping cost calculation
-
-	[Fact]
-	public async Task Checkout_ShouldUseZeroShipping_ForHandToHand()
-	{
-		// Arrange — We can verify the logic by checking product status changes
-		var book = new Book
-		{
-			AdvertId = 10,
-			Title = "HTH Book",
-			Description = "Hand to hand delivery",
-			Price = 100m,
-			SellerId = "seller-1",
-			ISBN = "12345",
-			Author = "Author",
-			Publisher = "Pub",
-			Edition = "1st",
-			WrittenLanguage = LanguageEnum.FR,
-			Status = AdvertStatus.ACTIVE
-		};
-		_context.Products.Add(book);
-		await _context.SaveChangesAsync();
-
-		var request = new CheckoutRequestDto
-		{
-			ProductIds = new List<long> { 10L },
-			ProductPrice = 100.0,
-			ShippingMethod = "handToHand"
-		};
-
-		// Act — This will fail at Stripe session creation (no real Stripe key),
-		// but the validation and status update should have run
-		try
-		{
-			await _controller.Checkout(request);
-		}
-		catch
-		{
-			// Expected: Stripe call fails in unit test context
-		}
-
-		// Assert — Product should have been paused (validation passed)
-		var advertInDb = await _context.Adverts.FindAsync(10L);
-		advertInDb!.Status.Should().Be(AdvertStatus.PAUSED);
-	}
-
-	#endregion
-
-	#region Product status management during checkout
-
-	[Fact]
-	public async Task Checkout_ShouldSetProductStatusToPaused_WhenValidRequest()
-	{
-		// Arrange
-		var book = new Book
-		{
-			AdvertId = 20,
-			Title = "Active Book",
-			Description = "Should be paused",
-			Price = 50m,
-			SellerId = "seller-1",
-			ISBN = "12345",
-			Author = "Author",
-			Publisher = "Pub",
-			Edition = "1st",
-			WrittenLanguage = LanguageEnum.FR,
-			Status = AdvertStatus.ACTIVE
-		};
-		_context.Products.Add(book);
-		await _context.SaveChangesAsync();
-
-		var request = new CheckoutRequestDto
-		{
-			ProductIds = new List<long> { 20L },
-			ProductPrice = 50.0,
-			ShippingMethod = "handToHand"
-		};
-
-		// Act
-		try
-		{
-			await _controller.Checkout(request);
-		}
-		catch
-		{
-			// Expected: Stripe call fails in unit test context
-		}
-
-		// Assert
-		var advertInDb = await _context.Adverts.FindAsync(20L);
-		advertInDb!.Status.Should().Be(AdvertStatus.PAUSED);
-	}
-
-	[Fact]
-	public async Task Checkout_ShouldSetMultipleProductsToPaused()
-	{
-		// Arrange
-		var book1 = new Book
-		{
-			AdvertId = 30,
-			Title = "Book 1",
-			Description = "First",
-			Price = 25m,
-			SellerId = "seller-1",
-			ISBN = "11111",
-			Author = "A1",
-			Publisher = "P1",
-			Edition = "1st",
-			WrittenLanguage = LanguageEnum.FR,
-			Status = AdvertStatus.ACTIVE
-		};
-		var book2 = new Book
-		{
-			AdvertId = 31,
-			Title = "Book 2",
-			Description = "Second",
-			Price = 35m,
-			SellerId = "seller-2",
-			ISBN = "22222",
-			Author = "A2",
-			Publisher = "P2",
-			Edition = "2nd",
-			WrittenLanguage = LanguageEnum.FR,
-			Status = AdvertStatus.ACTIVE
-		};
-		_context.Products.AddRange(book1, book2);
-		await _context.SaveChangesAsync();
-
-		var request = new CheckoutRequestDto
-		{
-			ProductIds = new List<long> { 30L, 31L },
-			ProductPrice = 60.0,
-			ShippingMethod = "postal"
-		};
-
-		// Act
-		try
-		{
-			await _controller.Checkout(request);
-		}
-		catch
-		{
-			// Expected: Stripe call fails in unit test context
-		}
-
-		// Assert
-		var advert1 = await _context.Adverts.FindAsync(30L);
-		var advert2 = await _context.Adverts.FindAsync(31L);
-		advert1!.Status.Should().Be(AdvertStatus.PAUSED);
-		advert2!.Status.Should().Be(AdvertStatus.PAUSED);
-	}
-
-	#endregion
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status502BadGateway);
+    }
 }

--- a/EcoScolarWebApi.Tests/Unit/Controllers/ReportsControllerTests.cs
+++ b/EcoScolarWebApi.Tests/Unit/Controllers/ReportsControllerTests.cs
@@ -75,7 +75,7 @@ public class ReportsControllerTests
 			ReporterUserId = "user-123",
 			Reason = ReportReason.INAPPROPRIATE_ADVERT,
 			Message = "Offensive content",
-			Status = TicketStatus.Pending,
+			Status = TicketStatus.PENDING,
 			CreatedAt = DateTime.UtcNow
 		};
 
@@ -117,7 +117,7 @@ public class ReportsControllerTests
 				ReporterUserId = "user-456",
 				Reason = ReportReason.INAPPROPRIATE_COMMENT,
 				Message = "Rude comment",
-				Status = TicketStatus.Pending,
+				Status = TicketStatus.PENDING,
 				CreatedAt = DateTime.UtcNow
 			});
 

--- a/EcoScolarWebApi.Tests/Unit/Services/PaymentServiceTests.cs
+++ b/EcoScolarWebApi.Tests/Unit/Services/PaymentServiceTests.cs
@@ -232,6 +232,46 @@ public class PaymentServiceTests : IDisposable
         await act.Should().NotThrowAsync();
     }
 
+    [Fact]
+    public async Task ConfirmCheckoutSession_TutoringAdvert_BecomesWaitingAcceptance_AndAdvertStaysActive()
+    {
+        var tutoring = new TutoringAdvert
+        {
+            Title = "Maths",
+            Description = "desc",
+            Price = 30m,
+            Status = AdvertStatus.ACTIVE,
+            SellerId = SellerId,
+            NotificationDate = DateTime.UtcNow,
+            SubjectId = 1,
+            SchoolGradeId = 1,
+        };
+        _context.Adverts.Add(tutoring);
+        await _context.SaveChangesAsync();
+
+        _context.Transactions.Add(new Transaction
+        {
+            AdvertId = tutoring.AdvertId,
+            BuyerId = BuyerId,
+            Date = DateTime.UtcNow,
+            Status = TransactionStatus.PENDING,
+            StripeSessionId = "cs_tut_1",
+            Quantity = 5,
+            UnitPrice = 30m,
+            PlatformFee = 15m,
+            Amount = 165m,
+        });
+        await _context.SaveChangesAsync();
+
+        await _service.ConfirmCheckoutSessionAsync("cs_tut_1", "pi_tut");
+
+        var transaction = await _context.Transactions.SingleAsync();
+        // Tutoring waits for the tutor's acceptance and the advert is never marked SOLD.
+        transaction.Status.Should().Be(TransactionStatus.PAID_WAITING_ACCEPTANCE);
+        transaction.StripePaymentIntentId.Should().Be("pi_tut");
+        (await _context.Adverts.FindAsync(tutoring.AdvertId))!.Status.Should().Be(AdvertStatus.ACTIVE);
+    }
+
     // === webhook cancel / revert ===
 
     [Fact]

--- a/EcoScolarWebApi.Tests/Unit/Services/TutoringReservationServiceTests.cs
+++ b/EcoScolarWebApi.Tests/Unit/Services/TutoringReservationServiceTests.cs
@@ -1,0 +1,180 @@
+using EcoScolarWebApi.Commun;
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.Enums;
+using EcoScolarWebApi.Models;
+using EcoScolarWebApi.Services;
+using EcoScolarWebApi.Services.Contracts;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Stripe.Checkout;
+using Xunit;
+
+namespace EcoScolarWebApi.Tests.Unit.Services;
+
+public class TutoringReservationServiceTests : IDisposable
+{
+    private const string BuyerId = "buyer-1";
+    private const string SellerId = "tutor-1";
+    private const string BaseUrl = "http://localhost:3000";
+
+    private readonly EcoscolarDbContext _context;
+    private readonly IPlatformFeeCalculator _feeCalculator;
+    private readonly IStripeCheckoutClient _checkoutClient;
+    private readonly TutoringReservationService _service;
+
+    public TutoringReservationServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<EcoscolarDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _context = new EcoscolarDbContext(options);
+
+        // Deterministic 10% fee, matching the configured default.
+        _feeCalculator = Substitute.For<IPlatformFeeCalculator>();
+        _feeCalculator.CalculateFee(Arg.Any<decimal>())
+            .Returns(ci => Math.Round((decimal)ci[0] * 0.1m, 2, MidpointRounding.AwayFromZero));
+
+        _checkoutClient = Substitute.For<IStripeCheckoutClient>();
+        _checkoutClient.CreateSessionAsync(Arg.Any<SessionCreateOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new Session { Id = "cs_tutoring_123", Url = "https://stripe.test/checkout" });
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BusinessSettings:TutoringPackageValidityDays"] = "15",
+            })
+            .Build();
+
+        _service = new TutoringReservationService(
+            _context, _feeCalculator, _checkoutClient, config,
+            Substitute.For<ILogger<TutoringReservationService>>());
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<TutoringAdvert> SeedTutoringAsync(
+        decimal price = 30m, AdvertStatus status = AdvertStatus.ACTIVE,
+        string sellerId = SellerId, int maxHours = 10, int? minHours = 1)
+    {
+        var advert = new TutoringAdvert
+        {
+            Title = "Cours de maths",
+            Description = "desc",
+            Price = price,
+            Status = status,
+            SellerId = sellerId,
+            NotificationDate = DateTime.UtcNow,
+            SubjectId = 1,
+            SchoolGradeId = 1,
+            StudyLevel = "Secondaire",
+            MaxHours = maxHours,
+            MinHours = minHours,
+        };
+        _context.Services.Add(advert);
+        await _context.SaveChangesAsync();
+        return advert;
+    }
+
+    [Fact]
+    public async Task Reserve_PricesServerSide_AndCreatesPendingTransaction_AdvertStaysActive()
+    {
+        var advert = await SeedTutoringAsync(price: 30m);
+
+        var result = await _service.CreateReservationSessionAsync(advert.AdvertId, hours: 5, BuyerId, BaseUrl);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Data!.Url.Should().Be("https://stripe.test/checkout");
+        result.Data.OrderNumber.Should().NotBeNullOrWhiteSpace();
+
+        var transaction = await _context.Transactions.SingleAsync();
+        transaction.Status.Should().Be(TransactionStatus.PENDING);
+        transaction.BuyerId.Should().Be(BuyerId);
+        transaction.StripeSessionId.Should().Be("cs_tutoring_123");
+        transaction.Quantity.Should().Be(5);
+        transaction.UnitPrice.Should().Be(30m);
+        transaction.PlatformFee.Should().Be(15m);   // 10% of 150
+        transaction.Amount.Should().Be(165m);        // 150 + 15
+        transaction.PackageExpiresAt.Should().NotBeNull();
+        transaction.OrderNumber.Should().Be(result.Data.OrderNumber);
+
+        // A tutoring advert is never paused/sold: multiple students can book it in parallel.
+        (await _context.Services.FindAsync(advert.AdvertId))!.Status.Should().Be(AdvertStatus.ACTIVE);
+    }
+
+    [Fact]
+    public async Task Reserve_ReturnsBadRequest_WhenHoursExceedMax()
+    {
+        var advert = await SeedTutoringAsync(maxHours: 4);
+
+        var result = await _service.CreateReservationSessionAsync(advert.AdvertId, hours: 5, BuyerId, BaseUrl);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorType.Should().Be(ErrorType.BadRequest);
+        (await _context.Transactions.AnyAsync()).Should().BeFalse();
+        await _checkoutClient.DidNotReceive().CreateSessionAsync(Arg.Any<SessionCreateOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reserve_ReturnsBadRequest_WhenHoursBelowMin()
+    {
+        var advert = await SeedTutoringAsync(minHours: 3);
+
+        var result = await _service.CreateReservationSessionAsync(advert.AdvertId, hours: 2, BuyerId, BaseUrl);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorType.Should().Be(ErrorType.BadRequest);
+    }
+
+    [Fact]
+    public async Task Reserve_ReturnsNotFound_WhenAdvertMissing()
+    {
+        var result = await _service.CreateReservationSessionAsync(999, hours: 2, BuyerId, BaseUrl);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorType.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public async Task Reserve_ReturnsConflict_WhenAdvertNotActive()
+    {
+        var advert = await SeedTutoringAsync(status: AdvertStatus.PAUSED);
+
+        var result = await _service.CreateReservationSessionAsync(advert.AdvertId, hours: 2, BuyerId, BaseUrl);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorType.Should().Be(ErrorType.Conflict);
+    }
+
+    [Fact]
+    public async Task Reserve_ReturnsConflict_WhenReservingOwnAdvert()
+    {
+        var advert = await SeedTutoringAsync(sellerId: BuyerId);
+
+        var result = await _service.CreateReservationSessionAsync(advert.AdvertId, hours: 2, BuyerId, BaseUrl);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorType.Should().Be(ErrorType.Conflict);
+    }
+
+    [Fact]
+    public async Task Reserve_DoesNotTouchDb_WhenStripeFails()
+    {
+        var advert = await SeedTutoringAsync();
+        _checkoutClient.CreateSessionAsync(Arg.Any<SessionCreateOptions>(), Arg.Any<CancellationToken>())
+            .Returns<Session>(_ => throw new Stripe.StripeException("boom"));
+
+        var result = await _service.CreateReservationSessionAsync(advert.AdvertId, hours: 3, BuyerId, BaseUrl);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorType.Should().Be(ErrorType.InternalError);
+        (await _context.Transactions.AnyAsync()).Should().BeFalse();
+    }
+}

--- a/EcoScolarWebApi/Controllers/TutoringController.cs
+++ b/EcoScolarWebApi/Controllers/TutoringController.cs
@@ -1,0 +1,69 @@
+using Asp.Versioning;
+using EcoScolarWebApi.Commun;
+using EcoScolarWebApi.DTOs.Tutoring;
+using EcoScolarWebApi.Models;
+using EcoScolarWebApi.Services.Contracts;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EcoScolarWebApi.Controllers;
+
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
+[ApiController]
+[Authorize]
+public class TutoringController(ITutoringReservationService reservationService, UserManager<User> userManager) : ControllerBase
+{
+	/// <summary>
+	/// Reserves a tutoring package (a number of hours) and returns a Stripe Checkout session URL.
+	/// The price is computed server-side from the advert's hourly rate; the client only sends the hours.
+	///
+	/// Url: POST /api/v1/tutoring/{advertId}/reserve
+	/// </summary>
+	[HttpPost("{advertId}/reserve")]
+    public async Task<IActionResult> Reserve(long advertId, [FromBody] TutoringReserveRequestDto request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var buyerId = userManager.GetUserId(User);
+        if (string.IsNullOrEmpty(buyerId))
+            return Unauthorized();
+
+        var baseUrl = ResolveFrontendBaseUrl();
+
+        var result = await reservationService.CreateReservationSessionAsync(advertId, request.Hours, buyerId, baseUrl);
+        if (result.IsSuccess)
+            return Ok(new { url = result.Data!.Url, orderNumber = result.Data.OrderNumber });
+
+        return result.ErrorType switch
+        {
+            ErrorType.NotFound => NotFound(new { result.Errors }),
+            ErrorType.Conflict => Conflict(new { result.Errors }),
+            ErrorType.InternalError => StatusCode(StatusCodes.Status502BadGateway, new { result.Errors }),
+            _ => BadRequest(new { result.Errors }),
+        };
+    }
+
+    /// <summary>
+    /// Resolves the frontend base URL from the Referer header, falling back to the request host.
+    /// </summary>
+    private string ResolveFrontendBaseUrl()
+    {
+        if (Request.Headers.TryGetValue("Referer", out var refererHeader) && !string.IsNullOrEmpty(refererHeader))
+        {
+            try
+            {
+                var uri = new Uri(refererHeader.ToString());
+                return $"{uri.Scheme}://{uri.Authority}";
+            }
+            catch
+            {
+                // Fallback below in case of a malformed Referer.
+            }
+        }
+
+        return $"{Request.Scheme}://{Request.Host}";
+    }
+}

--- a/EcoScolarWebApi/DTOs/Tutoring/TutoringReserveRequestDto.cs
+++ b/EcoScolarWebApi/DTOs/Tutoring/TutoringReserveRequestDto.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EcoScolarWebApi.DTOs.Tutoring;
+
+/// <summary>
+/// Booking request for a tutoring advert. The advert id comes from the route;
+/// the body only carries the number of hours. The price is computed server-side.
+/// </summary>
+public class TutoringReserveRequestDto
+{
+    /// <summary>Number of hours to book. Bounded server-side by the advert's MinHours/MaxHours.</summary>
+    [Range(1, 1000, ErrorMessage = "Le nombre d'heures doit être positif.")]
+    public int Hours { get; set; }
+}

--- a/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/EcoScolarWebApi/Extensions/ServiceCollectionExtensions.cs
@@ -133,6 +133,7 @@ public static class ServiceCollectionExtensions
 		services.AddSingleton<IShippingFeeCalculator, ShippingFeeCalculator>();
 		services.AddSingleton<IStripeCheckoutClient, StripeCheckoutClient>();
 		services.AddScoped<IPaymentService, PaymentService>();
+		services.AddScoped<ITutoringReservationService, TutoringReservationService>();
 
 		// MinIO image storage
 		var minioEndpoint = config["Minio:Endpoint"].NullIfEmpty() ?? "localhost:9000";

--- a/EcoScolarWebApi/Services/Contracts/ITutoringReservationService.cs
+++ b/EcoScolarWebApi/Services/Contracts/ITutoringReservationService.cs
@@ -1,0 +1,19 @@
+using EcoScolarWebApi.Commun;
+using EcoScolarWebApi.DTOs.Stripe;
+
+namespace EcoScolarWebApi.Services.Contracts;
+
+/// <summary>
+/// Dedicated reservation flow for tutoring adverts (hours credit + escrow), separate from the
+/// cart checkout. Validates and prices the booking server-side, creates a single pending
+/// transaction and returns the Stripe Checkout session URL. The transaction becomes
+/// PAID_WAITING_ACCEPTANCE on payment (handled by the shared payment webhook).
+/// </summary>
+public interface ITutoringReservationService
+{
+    /// <summary>
+    /// Validates the advert and hours, prices the package server-side, creates a PENDING
+    /// transaction (advert stays ACTIVE) and returns the Stripe Checkout session URL.
+    /// </summary>
+    Task<Result<CheckoutSessionResultDto>> CreateReservationSessionAsync(long advertId, int hours, string buyerId, string baseUrl);
+}

--- a/EcoScolarWebApi/Services/PaymentService.cs
+++ b/EcoScolarWebApi/Services/PaymentService.cs
@@ -178,10 +178,19 @@ public class PaymentService : IPaymentService
         {
             transaction.StripePaymentIntentId = paymentIntentId;
 
-            // Physical goods: paid, waiting for the seller to ship.
-            transaction.Status = TransactionStatus.PAID_WAITING_SHIPPING;
-            if (transaction.Advert is not null)
-                transaction.Advert.Status = AdvertStatus.SOLD;
+            if (transaction.Advert is TutoringAdvert)
+            {
+                // Tutoring package: awaits the tutor's accept/refuse decision (UC-09 E6-02).
+                // The advert stays ACTIVE so other students can keep booking the same tutor.
+                transaction.Status = TransactionStatus.PAID_WAITING_ACCEPTANCE;
+            }
+            else
+            {
+                // Physical goods: paid, waiting for the seller to ship.
+                transaction.Status = TransactionStatus.PAID_WAITING_SHIPPING;
+                if (transaction.Advert is not null)
+                    transaction.Advert.Status = AdvertStatus.SOLD;
+            }
         }
 
         await _context.SaveChangesAsync(cancellationToken);

--- a/EcoScolarWebApi/Services/TutoringReservationService.cs
+++ b/EcoScolarWebApi/Services/TutoringReservationService.cs
@@ -1,0 +1,138 @@
+using EcoScolarWebApi.Commun;
+using EcoScolarWebApi.Data;
+using EcoScolarWebApi.DTOs.Stripe;
+using EcoScolarWebApi.Enums;
+using EcoScolarWebApi.Models;
+using EcoScolarWebApi.Services.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Stripe.Checkout;
+
+namespace EcoScolarWebApi.Services;
+
+/// <summary>
+/// Tutoring reservation. Reuses the server-authoritative pricing primitives
+/// (<see cref="IPlatformFeeCalculator"/>, <see cref="IStripeCheckoutClient"/>) but on a dedicated
+/// path: tutoring is never sold through the cart. See <see cref="ITutoringReservationService"/>.
+/// </summary>
+public class TutoringReservationService(
+	EcoscolarDbContext context,
+	IPlatformFeeCalculator feeCalculator,
+	IStripeCheckoutClient checkoutClient,
+	IConfiguration configuration,
+	ILogger<TutoringReservationService> logger) : ITutoringReservationService
+{
+	private const int DefaultPackageValidityDays = 15;
+	private readonly int _packageValidityDays = configuration.GetValue("BusinessSettings:TutoringPackageValidityDays", DefaultPackageValidityDays);
+
+	public async Task<Result<CheckoutSessionResultDto>> CreateReservationSessionAsync(long advertId, int hours, string buyerId, string baseUrl)
+	{
+		var advert = await context.Services.FirstOrDefaultAsync(a => a.AdvertId == advertId);
+		if (advert is null)
+			return Result<CheckoutSessionResultDto>.Failure("Le cours d'appui spécifié n'existe pas.", ErrorType.NotFound);
+
+		if (advert.Status != AdvertStatus.ACTIVE)
+			return Result<CheckoutSessionResultDto>.Failure("Ce cours d'appui n'est pas disponible à la réservation.", ErrorType.Conflict);
+
+		if (advert.SellerId == buyerId)
+			return Result<CheckoutSessionResultDto>.Failure("Vous ne pouvez pas réserver votre propre cours d'appui.", ErrorType.Conflict);
+
+		var minHours = advert.MinHours ?? 1;
+		if (hours < minHours || hours > advert.MaxHours)
+			return Result<CheckoutSessionResultDto>.Failure(
+				$"Le nombre d'heures doit être compris entre {minHours} et {advert.MaxHours}.", ErrorType.BadRequest);
+
+		// Pricing is authoritative server-side: hourly rate × hours, plus the platform fee.
+		var unitPrice = advert.Price;
+		var subtotal = unitPrice * hours;
+		var fee = feeCalculator.CalculateFee(subtotal);
+		var total = subtotal + fee;
+		var amountInCents = (long)Math.Round(total * 100, MidpointRounding.AwayFromZero);
+
+		var orderNumber = await GenerateUniqueOrderNumberAsync();
+
+		var metadata = new Dictionary<string, string>
+		{
+			["orderNumber"] = orderNumber,
+			["buyerId"] = buyerId,
+			["advertId"] = advertId.ToString(),
+			["hours"] = hours.ToString(),
+			["type"] = "tutoring",
+		};
+
+		var options = new SessionCreateOptions
+		{
+			PaymentMethodTypes = ["card"],
+			LineItems =
+			[
+				new()
+				{
+					PriceData = new SessionLineItemPriceDataOptions
+					{
+						UnitAmount = amountInCents,
+						Currency = "chf",
+						ProductData = new SessionLineItemPriceDataProductDataOptions
+						{
+							Name = "Réservation de cours d'appui",
+							Description = $"{hours} h — {advert.Title}",
+						},
+					},
+					Quantity = 1,
+				},
+			],
+			Mode = "payment",
+			// Escrowed on the platform account; orderNumber is reused as the transfer group at payout time.
+			PaymentIntentData = new SessionPaymentIntentDataOptions
+			{
+				TransferGroup = orderNumber,
+				Metadata = metadata,
+			},
+			Metadata = metadata,
+			SuccessUrl = $"{baseUrl}/success?productIds={advertId}&orderId={orderNumber}",
+			CancelUrl = $"{baseUrl}/denied?productIds={advertId}",
+		};
+
+		Session session;
+		try
+		{
+			session = await checkoutClient.CreateSessionAsync(options);
+		}
+		catch (Stripe.StripeException e)
+		{
+			logger.LogError(e, "Stripe reservation session creation failed for tutoring advert {AdvertId}.", advertId);
+			return Result<CheckoutSessionResultDto>.Failure(e.StripeError?.Message ?? e.Message, ErrorType.InternalError);
+		}
+
+		// Only mutate the DB once Stripe accepted the session. The advert stays ACTIVE:
+		// several students can hold packages on the same tutoring advert in parallel.
+		var now = DateTime.UtcNow;
+		context.Transactions.Add(new Transaction
+		{
+			AdvertId = advert.AdvertId,
+			BuyerId = buyerId,
+			Date = now,
+			Status = TransactionStatus.PENDING,
+			OrderNumber = orderNumber,
+			StripeSessionId = session.Id,
+			Quantity = hours,
+			UnitPrice = unitPrice,
+			PlatformFee = fee,
+			Amount = total,
+			PackageExpiresAt = now.AddDays(_packageValidityDays),
+		});
+
+		await context.SaveChangesAsync();
+
+		return Result<CheckoutSessionResultDto>.Success(new CheckoutSessionResultDto(session.Url, orderNumber));
+	}
+
+	private async Task<string> GenerateUniqueOrderNumberAsync()
+	{
+		string orderNumber;
+		do
+		{
+			orderNumber = $"ECO-{DateTime.UtcNow:yyyyMMdd}-{System.Security.Cryptography.RandomNumberGenerator.GetInt32(0, 1_000_000):D6}";
+		}
+		while (await context.Transactions.AnyAsync(t => t.OrderNumber == orderNumber));
+		return orderNumber;
+	}
+}


### PR DESCRIPTION
## Étape D — Réservation de cours d'appui (vente de tutorat)

Ajoute le flux de **réservation** d'un cours d'appui : l'élève choisit un nombre d'heures, paie via Stripe, et une transaction est créée en séquestre. Première brique fonctionnelle côté API du parcours tutorat (UC-09 E6-01).

> Dépend de P1–P4 (checkout sécurisé + webhook), déjà sur `develop`. Cible : `develop`.

### Ce que contient la PR
- **`POST /api/v1/tutoring/{advertId}/reserve`** (`TutoringController`) — réserve N heures, prix calculé serveur, renvoie l'URL Stripe.
- **`ITutoringReservationService` / `TutoringReservationService`** — validation `Min/MaxHours`, prix `tarif horaire × heures + commission`, session Stripe (metadata), transaction `PENDING`. L'annonce **reste `ACTIVE`** (plusieurs élèves peuvent réserver en parallèle).
- **Webhook** — `PaymentService.ConfirmCheckoutSessionAsync` bascule désormais les transactions de tutorat vers **`PAID_WAITING_ACCEPTANCE`** (au lieu de `PAID_WAITING_SHIPPING`), sans marquer l'annonce `SOLD`.
- Correction de la dette de compilation du projet de test laissée par le refactor paiements/DTO (commit séparé).

### Contrat de l'endpoint (pour le front)
```bash
POST /api/v1/tutoring/{advertId}/reserve (Authorize)
Body: { "hours": 5 }
200 → { "url": "https://checkout.stripe.com/...", "orderNumber": "ECO-..." } → rediriger vers url
400 → heures hors bornes (min/max de l'annonce)
404 → annonce inexistante
409 → annonce indisponible / propre annonce
502 → erreur Stripe
```

Le prix est **autoritaire côté serveur** ; le front n'envoie que `hours`. `ServiceReadDto` expose déjà `pricePerHour` / `maxHours` / `minHours` pour le modal.

### Périmètre front (à faire dans une autre PR)
- ✅ Débloqué : bouton « Réserver » + modal (heures plafonnées à `maxHours`), retrait du bouton panier pour les services, page `success.vue` qui ne marque plus `SOLD` (l'état vient du webhook).
- ⏳ Pas encore : écrans post-achat (coordonnées du tuteur, confirmation/refus) — dépendent des endpoints E/F non encore implémentés.

### Tests
- `TutoringReservationServiceTests` (validation, pricing serveur, annonce reste `ACTIVE`, échec Stripe sans écriture DB).
- Cas tutorat ajouté à `PaymentServiceTests` (confirm → `PAID_WAITING_ACCEPTANCE`, annonce `ACTIVE`).
- **261/261 tests unitaires verts.**

### Notes de déploiement
- `Stripe:WebhookSecret` doit être configuré dans l'environnement, sinon la transaction reste `PENDING`.
- Aucune migration dans cette PR (colonnes/statuts déjà livrés par les fondations).